### PR TITLE
feat: support direct plan-based init

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Claude Code only runs custom statusline commands after the current workspace is 
 - **Pro / Max**: model name plus colorized 5-hour and 7-day rate-limit utilization.
 - **Enterprise**: model name plus dollars-used / dollars-limit when monthly credits are enabled. Falls back to colorized 5-hour and 7-day rate-limit utilization.
 
+Pro and Max use the same renderer. They are separate installer choices only because Claude users know their subscription by those names; Claude Code exposes the same statusline usage fields for both.
+
 Example Pro / Max output:
 
 ```text

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,17 +7,24 @@ import { runRenderEnterprise } from './subcommands/render-enterprise';
 const HELP = `cc-statusline — usage-aware Claude Code statusline + installer
 
 Usage:
-  cc-statusline init [--plan=pro|max|enterprise] [--credentials-path=<path>] [--force]
+  cc-statusline [--plan pro|max|enterprise] [--credentials-path=<path>] [--force]
+  cc-statusline init [--plan pro|max|enterprise] [--credentials-path=<path>] [--force]
   cc-statusline uninstall
   cc-statusline render-promax       (invoked by Claude Code; reads stdin)
   cc-statusline render-enterprise   (invoked by Claude Code; reads stdin)
   cc-statusline refresh             (background token + usage refresh)
 
-Run \`npx cc-statusline init\` to get started.
+Pro and Max use the same renderer; Enterprise uses cache-backed OAuth usage.
+
+Run \`npx cc-statusline --plan pro\` to get started.
 `;
 
 async function main(argv: string[]): Promise<number> {
   const cmd = argv[2];
+
+  if (cmd?.startsWith('--') && cmd !== '--help') {
+    return runInit(argv.slice(2));
+  }
 
   switch (cmd) {
     case 'init':

--- a/src/subcommands/init.ts
+++ b/src/subcommands/init.ts
@@ -232,13 +232,22 @@ export async function runInit(args: string[], deps: InitDeps = {}): Promise<numb
   let credentialsPathFlag: string | undefined;
   let forceFlag = false;
 
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
     if (arg.startsWith('--plan=')) {
       const val = arg.slice('--plan='.length).toLowerCase();
       if (val === 'pro' || val === 'max' || val === 'enterprise') {
         planFlag = val;
       } else {
         process.stderr.write(`init: unknown plan "${val}"; expected pro, max, or enterprise\n`);
+        return 1;
+      }
+    } else if (arg === '--plan') {
+      const val = args[++i]?.toLowerCase();
+      if (val === 'pro' || val === 'max' || val === 'enterprise') {
+        planFlag = val;
+      } else {
+        process.stderr.write(`init: unknown plan "${val ?? ''}"; expected pro, max, or enterprise\n`);
         return 1;
       }
     } else if (arg.startsWith('--credentials-path=')) {

--- a/tests/build-smoke.test.ts
+++ b/tests/build-smoke.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { builtinModules } from 'node:module';
-import { readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
 const BUNDLE = resolve(__dirname, '..', 'dist', 'cli.cjs');
@@ -31,6 +32,28 @@ describe('build smoke', () => {
     const result = spawnSync(process.execPath, [BUNDLE, '--help'], { encoding: 'utf8' });
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('Pro and Max use the same renderer');
+  });
+
+  it('runs init directly with --plan pro --force', () => {
+    const home = mkdtempSync(resolve(tmpdir(), 'cc-statusline-npx-'));
+    const claudeDir = resolve(home, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+
+    const result = spawnSync(
+      process.execPath,
+      [BUNDLE, '--plan', 'pro', '--force'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: home, CLAUDE_CONFIG_DIR: claudeDir },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Pro/Max statusline installed');
+
+    const settings = JSON.parse(readFileSync(resolve(claudeDir, 'settings.json'), 'utf8'));
+    expect(settings.statusLine.command).toContain('render-promax');
   });
 
   it('exits non-zero on unknown subcommand', () => {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -215,6 +215,20 @@ describe('T2: happy path Pro non-interactive --plan=pro', () => {
     expect(s.statusLine?.command).toMatch(/render-promax/);
     expect(fs.existsSync(cachePath(tmpDir))).toBe(false);
   });
+
+  it('accepts --plan with a separate value', async () => {
+    const tmpDir = makeTmpDir();
+    makeFakeBundle(tmpDir);
+
+    const deps = baseDeps(tmpDir, { isInteractive: false });
+
+    const code = await runInit(['--plan', 'pro'], deps);
+    expect(code).toBe(0);
+
+    const s = readSettings(settingsPath(tmpDir));
+    expect(s.statusLine?.command).toMatch(/render-promax/);
+    expect(fs.existsSync(cachePath(tmpDir))).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -299,6 +313,34 @@ describe('T4: happy path Enterprise non-interactive with --credentials-path', ()
     expect(cache?.authState).toBe('ok');
 
     // Settings has render-enterprise
+    const s = readSettings(settingsPath(tmpDir));
+    expect(s.statusLine?.command).toMatch(/render-enterprise/);
+  });
+
+  it('accepts --plan enterprise with a separate value', async () => {
+    const tmpDir = makeTmpDir();
+    makeFakeBundle(tmpDir);
+
+    const credFile = path.join(tmpDir, '.claude', 'test-creds.json');
+    fs.mkdirSync(path.dirname(credFile), { recursive: true });
+    fs.writeFileSync(credFile, JSON.stringify(VALID_ENVELOPE), 'utf8');
+
+    const discoverSpy = vi.fn();
+    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
+
+    const deps = baseDeps(tmpDir, {
+      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
+      spawnRefresh: spawnSpy,
+    });
+
+    const code = await runInit(
+      ['--plan', 'enterprise', `--credentials-path=${credFile}`, '--force'],
+      deps,
+    );
+    expect(code).toBe(0);
+    expect(discoverSpy).not.toHaveBeenCalled();
+    expect(spawnSpy).toHaveBeenCalledOnce();
+
     const s = readSettings(settingsPath(tmpDir));
     expect(s.statusLine?.command).toMatch(/render-enterprise/);
   });


### PR DESCRIPTION
## Summary

`cc-statusline` can now be installed directly from `npx` with plan flags, so users can run `npx cc-statusline --plan pro --force` without remembering the `init` subcommand.

This keeps the explicit `init` path available while documenting why Pro and Max share the same renderer and adding coverage for separate `--plan` values.

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm pack --dry-run --json`