### PR TITLE
fix: build before release smoke tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
 
       - run: npm run typecheck
 
-      - run: npm test
-
       - run: npm run build
+
+      - run: npm test
 
       - run: npm publish --provenance --access public
         env:


### PR DESCRIPTION
## Summary

The release workflow now builds the package before running tests, matching CI and ensuring bundle smoke tests can find `dist/cli.cjs` before publish.

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test`