### PR TITLE
fix: publish under scoped npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Usage-aware [Claude Code](https://code.claude.com) statusline. Shows your curren
 ## Install
 
 ```bash
-npx cc-statusline init
+npx @nkootstra/cc-statusline --plan pro
 ```
 
-The installer asks which plan you're on (Pro / Max / Enterprise) and writes the statusline command into `~/.claude/settings.json`.
+Use `--plan pro`, `--plan max`, or `--plan enterprise`. The installer writes the statusline command into `~/.claude/settings.json`.
 
 Claude Code only runs custom statusline commands after the current workspace is trusted. If you see `statusline skipped · restart to fix`, accept the workspace trust prompt for the project and restart Claude Code.
 
@@ -34,7 +34,7 @@ Opus 4.7 · $780.00 / $1000.00 (78%)
 ## Uninstall
 
 ```bash
-npx cc-statusline uninstall
+npx @nkootstra/cc-statusline uninstall
 ```
 
 Removes the statusline entry from `~/.claude/settings.json` and deletes the installed renderer. The OAuth refresh token is **not** revoked — it expires naturally.
@@ -45,4 +45,4 @@ cc-statusline reads Claude Code's stored OAuth credential (macOS keychain or `~/
 
 ## Release
 
-Releases are published to npm as `cc-statusline` from version tags (`v*`) through the GitHub Actions release workflow.
+Releases are published to npm as `@nkootstra/cc-statusline` from version tags (`v*`) through the GitHub Actions release workflow. The installed executable remains `cc-statusline`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cc-statusline",
+  "name": "@nkootstra/cc-statusline",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cc-statusline",
+      "name": "@nkootstra/cc-statusline",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cc-statusline",
+  "name": "@nkootstra/cc-statusline",
   "version": "0.1.0",
   "description": "Usage-aware Claude Code statusline + installer for Pro/Max and Enterprise users",
   "homepage": "https://github.com/nkootstra/cc-statusline#readme",
@@ -33,7 +33,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run typecheck && npm test && npm run build"
+    "prepublishOnly": "npm run typecheck && npm run build && npm test"
   },
   "dependencies": {
     "write-file-atomic": "^5.0.1"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ Usage:
 
 Pro and Max use the same renderer; Enterprise uses cache-backed OAuth usage.
 
-Run \`npx cc-statusline --plan pro\` to get started.
+Run \`npx @nkootstra/cc-statusline --plan pro\` to get started.
 `;
 
 async function main(argv: string[]): Promise<number> {


### PR DESCRIPTION
## Summary

The npm release now targets `@nkootstra/cc-statusline`, which avoids npm's similarity block on the unscoped `cc-statusline` package name while keeping the installed executable as `cc-statusline`.

This also aligns the `prepublishOnly` lifecycle order with CI and the release workflow so bundle smoke tests run after `dist/cli.cjs` exists.

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm pack --dry-run --json`