### PR TITLE
feat: add governance docs and --version flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Something is broken
+labels: bug
+---
+
+**Plan tier** (pro / max / enterprise):
+
+**cc-statusline version** (from `npm list -g @nkootstra/cc-statusline`, or the version printed by the installer):
+
+**OS and Node version**:
+
+**What happened**:
+
+**What you expected**:
+
+**Relevant output** (redact any token values before pasting):
+
+```
+paste here
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature request
+about: Propose a change or addition
+labels: enhancement
+---
+
+**Problem this solves**:
+
+**Proposed solution**:
+
+**Alternatives considered**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What
+
+<!-- one or two sentences -->
+
+Closes #
+
+## Checklist
+
+- [ ] `npm test` passes
+- [ ] `npm run typecheck` passes
+- [ ] Any changes in `credentials/`, `oauth/`, or `cache/` were discussed in the linked issue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# cc-statusline
+
+Usage-aware Claude Code statusline. The CLI reads OAuth tokens from the macOS keychain or `~/.claude/.credentials.json`, caches them at `~/.claude/cc-statusline/cache.json`, and renders usage in the Claude Code prompt area.
+
+## Stack
+
+- TypeScript strict; `noUncheckedIndexedAccess` is on — `arr[i]` yields `T | undefined`.
+- vitest (`environment: 'node'`, 15s timeout); tsup builds a single-file CJS bundle to `dist/cli.cjs`.
+- Sole runtime dep: `write-file-atomic` (bundled via `noExternal`).
+- Node 18+.
+
+## Development
+
+Run before declaring a change done:
+
+- `npm run typecheck`
+- `npm run build`
+- `npm test`
+
+`prepublishOnly` runs all three.
+
+## Security invariants — never violate
+
+- Every `child_process.spawn` call passes `shell: false` and an argv array. Never `shell: true`, never a single string command.
+- Cache files are written with mode `0600`. The install dir `~/.claude/cc-statusline/` is created with mode `0700`.
+- Any error string that may have originated from token-handling or HTTP response paths is passed through `sanitizeErrorMessage(message, credentials)` before being persisted (cache, log, stderr).
+- Any flag or input accepting a file path is validated with `fs.realpath` and rejected if it resolves outside the user's homedir or points to a non-regular file. Pattern: `validateCredentialsPath` in `src/subcommands/init.ts`.
+
+Changes inside `src/credentials/`, `src/oauth/`, or `src/cache/` require a design-discussed issue before any code is written. See `CONTRIBUTING.md`.
+
+## Test conventions
+
+- Tests must not touch real `~/.claude/`, the macOS keychain, or the network. Use `os.tmpdir()` + `mkdtempSync` for filesystem isolation.
+- Subcommand entrypoints accept a `Deps` interface (e.g. `InitDeps`) exposing override hooks: `homedirOverride`, `platformOverride`, `spawnRefresh`, `discoverImpl`, `pasteReader`, etc. Tests inject mocks via these; production calls omit them and get the defaults.
+- Mock only at system boundaries — filesystem, network, `child_process`, time. Never mock internal modules.
+- Fixtures live in `tests/fixtures/`.
+
+## OAuth result handling
+
+`refresh()` and `fetchUsage()` in `src/oauth/client.ts` return discriminated unions with a `kind` field: `success | auth-fatal | cloudflare-blocked | rate-limited | transient`. Every caller must handle every variant explicitly. Do not collapse to `try/catch` over the call.
+
+## Cache schema
+
+`Cache` in `src/cache/store.ts` carries a `schemaVersion` literal. Any shape change must bump the version, and `readCache` must return `null` for older versions so `init` rebuilds cleanly.
+
+## Bundle constraints
+
+- Cold-start budget: 150 ms on macOS/Linux, 250 ms on Windows. Enforced by `tests/build-smoke.test.ts`.
+- The bundle must not `require()` anything outside Node builtins. New deps go through `noExternal` in `tsup.config.ts` or get vendored.
+
+## Code style
+
+- No comments explaining what the code does. Comment only when the *why* is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug.
+- No block docstrings.
+
+## Bug fixing workflow
+
+1. Write a vitest test that reproduces the bug. Confirm it fails for the right reason.
+2. Fix the code.
+3. The new test must pass; the rest of the suite must not regress.
+4. Commit the failing test and the fix together.
+
+## Reference docs
+
+- `CONTRIBUTING.md` — issue/PR policy, repo layout, platform support, release process.
+- `SECURITY.md` — reporting channels, scope, implemented defences.
+- `docs/plans/` — historical implementation plans (read-only context).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+## Development setup
+
+Node 18 or later is required.
+
+```bash
+npm install
+npm run build      # tsup bundle → dist/
+npm test           # vitest
+npm run typecheck  # tsc --noEmit
+```
+
+`prepublishOnly` runs all three in sequence, so a passing publish means all three pass.
+
+## Project layout
+
+```
+src/
+  cache/          token + usage cache (read/write, 0600 mode)
+  credentials/    platform-aware OAuth credential discovery
+  oauth/          token refresh and usage API client
+  settings/       ~/.claude/settings.json mutator
+  statusline/     output formatter + stdin reader for Claude Code
+  subcommands/    init, uninstall, refresh, render-promax, render-enterprise
+tests/
+  fixtures/       static test inputs
+```
+
+## Opening an issue first
+
+Open an issue before writing code. This applies to bug fixes too — it avoids duplicate effort, confirms the bug is reproducible, and lets us agree on the right fix before you invest time in a PR.
+
+Changes in `credentials/`, `oauth/`, or `cache/` need an explicit **design discussion** in the issue before any code is written. These paths handle OAuth tokens, so "I'd like to refactor X" is not enough — the issue must agree on the approach first.
+
+## Submitting a PR
+
+- Keep PRs small and focused on one thing
+- `npm test` and `npm run typecheck` must pass
+- Fill in the PR template; the checklist is short
+
+## Code style
+
+TypeScript strict mode is enforced by `tsconfig.json`. Beyond that:
+
+- Comments only when the *why* is non-obvious — a hidden constraint, a subtle invariant, a workaround for a specific bug
+- No docstrings or block comments explaining what the code does
+
+## Platform support
+
+macOS and Linux are the primary targets. Windows code paths exist (`win32` branches in `init` and `buildCommand`) but are not covered by CI. Windows patches are welcome; they may not be merged without a test signal.
+
+## Release process
+
+Releases are published to npm automatically when a `v*` tag is pushed. Only the maintainer cuts releases.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Niels
+Copyright (c) 2026 Niels Kootstra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Example Enterprise output:
 Opus 4.7 · $780.00 / $1000.00 (78%)
 ```
 
+## Check version
+
+```bash
+npx @nkootstra/cc-statusline --version
+```
+
+`-v` works too.
+
 ## Uninstall
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported versions
+
+This project is pre-1.0. Only the latest published version on npm receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | yes       |
+| older   | no        |
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately via either channel:
+
+- **GitHub**: use [Security → Report a vulnerability](../../security/advisories/new) on this repository (private vulnerability reporting is enabled)
+- **Email**: niels.kootstra@pm.me
+
+Include as much detail as you can: steps to reproduce, affected version, and what you believe the impact to be. Please redact any token values from logs or output you share.
+
+I aim to acknowledge reports within **7 days**. Resolution timeline depends on severity; critical issues are prioritised.
+
+## Scope
+
+The following are in scope:
+
+- Credential or token exposure beyond the documented home-directory baseline (see [Out of scope](#out-of-scope))
+- Token values appearing in error messages, logs, or cache files
+- Path traversal via `--credentials-path` or any other flag accepting a file path
+- Cache or install directory created with permissions more permissive than `0600` / `0700`
+- Shell injection through any subprocess invocation
+
+## Implemented defences
+
+These mitigations are already in place. Reports for bypasses are in scope; reports that assume these are absent are not:
+
+- All subprocess spawns use `shell: false` — no shell injection via argument values
+- Error messages are sanitised before being written to cache: access and refresh token values are replaced with `<redacted>`
+- `--credentials-path` is validated via `realpath` and rejected if it resolves outside the user's home directory or points to a non-regular file
+- The cache file is written with mode `0600`; the install directory is created with mode `0700`
+
+## Out of scope
+
+If an attacker already has read access to your home directory, they can read the same OAuth tokens that Claude Code stores at `~/.claude/.credentials.json`. The cache at `~/.claude/cc-statusline/cache.json` does not increase that exposure. Home-directory-level compromise is out of scope.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nkootstra/cc-statusline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nkootstra/cc-statusline",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "write-file-atomic": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nkootstra/cc-statusline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Usage-aware Claude Code statusline + installer for Pro/Max and Enterprise users",
   "homepage": "https://github.com/nkootstra/cc-statusline#readme",
   "bugs": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,17 @@ import { runRefresh } from './subcommands/refresh';
 import { runRenderPromax } from './subcommands/render-promax';
 import { runRenderEnterprise } from './subcommands/render-enterprise';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const PKG_VERSION: string = ((): string => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require('../package.json') as { version: string };
+    return pkg.version;
+  } catch {
+    return '0.0.0';
+  }
+})();
+
 const HELP = `cc-statusline — usage-aware Claude Code statusline + installer
 
 Usage:
@@ -13,6 +24,7 @@ Usage:
   cc-statusline render-promax       (invoked by Claude Code; reads stdin)
   cc-statusline render-enterprise   (invoked by Claude Code; reads stdin)
   cc-statusline refresh             (background token + usage refresh)
+  cc-statusline --version           (print the installed version)
 
 Pro and Max use the same renderer; Enterprise uses cache-backed OAuth usage.
 
@@ -21,6 +33,11 @@ Run \`npx @nkootstra/cc-statusline --plan pro\` to get started.
 
 async function main(argv: string[]): Promise<number> {
   const cmd = argv[2];
+
+  if (cmd === '--version' || cmd === '-v') {
+    process.stdout.write(`${PKG_VERSION}\n`);
+    return 0;
+  }
 
   if (cmd?.startsWith('--') && cmd !== '--help') {
     return runInit(argv.slice(2));

--- a/tests/build-smoke.test.ts
+++ b/tests/build-smoke.test.ts
@@ -35,6 +35,15 @@ describe('build smoke', () => {
     expect(result.stdout).toContain('Pro and Max use the same renderer');
   });
 
+  it('prints the package version on --version', () => {
+    const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8')) as {
+      version: string;
+    };
+    const result = spawnSync(process.execPath, [BUNDLE, '--version'], { encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(pkg.version);
+  });
+
   it('runs init directly with --plan pro --force', () => {
     const home = mkdtempSync(resolve(tmpdir(), 'cc-statusline-npx-'));
     const claudeDir = resolve(home, '.claude');


### PR DESCRIPTION
## What

Bootstraps project governance (CONTRIBUTING.md, SECURITY.md, AGENTS.md, CLAUDE.md, issue/PR templates), fixes the LICENSE copyright name, and adds a `--version` / `-v` flag with a smoke test. Bumps to `0.1.1`.

Closes # (bootstrap PR — establishes the issues-first policy itself, so no pre-existing issue to link)

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Any changes in `credentials/`, `oauth/`, or `cache/` were discussed in the linked issue (n/a — no changes in those paths)