### PR TITLE
chore: bump GitHub Actions to v6 (Node 24 ready)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         node: [18, 20]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## What

Bumps `actions/checkout` and `actions/setup-node` from v4 to v6 in both CI and release workflows. Removes the Node 20 deprecation warnings ahead of the 2026-06-02 forced switch to Node 24 on GitHub Actions runners.

Closes # (maintenance — no behaviour change to the published package)

## Checklist

- [x] `npm test` passes (no test changes; CI verifies on Linux/macOS/Windows × Node 18/20)
- [x] `npm run typecheck` passes (no source changes)
- [x] Any changes in `credentials/`, `oauth/`, or `cache/` were discussed in the linked issue (n/a — workflow YAML only)