### PR TITLE
fix: thread injected clock through formatResetHint

### DIFF
--- a/src/statusline/format.ts
+++ b/src/statusline/format.ts
@@ -178,8 +178,15 @@ export function chooseLayout(stdoutColumns: number | undefined): Layout {
  *   future day        → `<weekday> HH:MM` (e.g. `Mon 14:30`)
  *
  * Uses `Intl.DateTimeFormat` for locale-aware HH:MM and weekday formatting.
+ *
+ * `now` is the reference clock in epoch ms. Callers in renderers thread their
+ * injected clock through here so output is deterministic in tests; defaults to
+ * `Date.now()` for ad-hoc callers.
  */
-export function formatResetHint(resetsAt: number | string | null | undefined): string {
+export function formatResetHint(
+  resetsAt: number | string | null | undefined,
+  now: number = Date.now(),
+): string {
   if (resetsAt === null || resetsAt === undefined) return MISSING;
   if (resetsAt === '') return MISSING;
   if (typeof resetsAt === 'number' && Number.isNaN(resetsAt)) return MISSING;
@@ -199,7 +206,6 @@ export function formatResetHint(resetsAt: number | string | null | undefined): s
   const resetDate = new Date(resetMs);
   if (!isFinite(resetDate.getTime())) return MISSING;
 
-  const now = Date.now();
   const diffMs = resetMs - now;
 
   // Treat dates in the past or at the current moment as missing.

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -110,13 +110,17 @@ function buildCostSegment(totalCostUsd: number): string {
   return `$${totalCostUsd.toFixed(2)}`;
 }
 
-function buildUsageBucketSegment(label: string, bucket: UsageBucket | null | undefined): string {
+function buildUsageBucketSegment(
+  label: string,
+  bucket: UsageBucket | null | undefined,
+  nowMs: number,
+): string {
   if (bucket === null || bucket === undefined) {
     return `${label} ${MISSING}`;
   }
 
   const pct = Math.round(bucket.utilization);
-  const hint = formatResetHint(bucket.resets_at ?? bucket.resetsAt);
+  const hint = formatResetHint(bucket.resets_at ?? bucket.resetsAt, nowMs);
   return [label, applyColor(`${pct}%`, colorTier(pct)), formatOptionalHint(hint)]
     .filter(Boolean)
     .join(' ');
@@ -146,10 +150,10 @@ function buildExtraUsageSegment(extra: ExtraUsage): string {
   return `$${usedDollars} / $${limitDollars} (${utilizationPct}%)`;
 }
 
-function buildFallbackUsageSegment(usage: UsageResponse): string {
+function buildFallbackUsageSegment(usage: UsageResponse, nowMs: number): string {
   return [
-    buildUsageBucketSegment('5h', usage.five_hour),
-    buildUsageBucketSegment('7d', usage.seven_day),
+    buildUsageBucketSegment('5h', usage.five_hour, nowMs),
+    buildUsageBucketSegment('7d', usage.seven_day, nowMs),
   ].join(' · ');
 }
 
@@ -160,7 +164,11 @@ function buildFallbackUsageSegment(usage: UsageResponse): string {
  * Staleness dim and STALE_MARKER are applied here.
  * Auth-state dim (fatal) is applied by the caller.
  */
-function buildUsageSegment(cache: Cache | null, isStale: boolean): { text: string; isFetching: boolean } {
+function buildUsageSegment(
+  cache: Cache | null,
+  isStale: boolean,
+  nowMs: number,
+): { text: string; isFetching: boolean } {
   if (cache === null || cache.usage === null) {
     return { text: `usage ${MISSING}${SEP}fetching…`, isFetching: true };
   }
@@ -169,7 +177,7 @@ function buildUsageSegment(cache: Cache | null, isStale: boolean): { text: strin
   const extra = usage.extra_usage;
   let figureSeg = extra?.is_enabled === true
     ? buildExtraUsageSegment(extra)
-    : buildFallbackUsageSegment(usage);
+    : buildFallbackUsageSegment(usage, nowMs);
 
   // Apply staleness dim + marker if needed.
   if (isStale) {
@@ -218,7 +226,7 @@ function renderLine(
   const costSeg = buildCostSegment(input.cost.total_cost_usd);
 
   // Build usage segment.
-  const { text: rawUsage, isFetching } = buildUsageSegment(cache, isStale);
+  const { text: rawUsage, isFetching } = buildUsageSegment(cache, isStale, nowMs);
 
   // Auth state overrides.
   let usageSeg = rawUsage;

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -307,6 +307,21 @@ describe('formatResetHint — relative phrasing', () => {
     const pastEpochSec = Math.floor(Date.now() / 1000) - 60;
     expect(formatResetHint(pastEpochSec)).toBe(MISSING);
   });
+
+  it('uses the injected `now` for same-day comparison, not the wall clock', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 14, 23, 0, 0));
+
+    const injectedNow = new Date(2026, 3, 15, 14, 0, 0).getTime();
+    const resetMs = new Date(2026, 3, 15, 15, 0, 0).getTime();
+    const resetEpochSec = Math.floor(resetMs / 1000);
+
+    const result = formatResetHint(resetEpochSec, injectedNow);
+
+    vi.useRealTimers();
+
+    expect(result).toBe('15:00');
+  });
 });
 
 describe('formatOptionalHint', () => {

--- a/tests/render-enterprise.test.ts
+++ b/tests/render-enterprise.test.ts
@@ -376,6 +376,8 @@ describe('Scenario 3 (AE7): extra_usage.is_enabled=false — 5h/7d fallback', ()
 
   it('treats fallback bucket utilization as percent and accepts resets_at', async () => {
     vi.stubEnv('NO_COLOR', '1');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 3, 12, 0, 0));
     const NOW = Date.now();
     const futureResetsAt = new Date(NOW + 3 * 60 * 60 * 1000).toISOString();
     const cache = makeCacheWithUsage(
@@ -393,10 +395,40 @@ describe('Scenario 3 (AE7): extra_usage.is_enabled=false — 5h/7d fallback', ()
       { now: () => NOW },
     );
 
+    vi.useRealTimers();
+
     expect(output).toMatch(/5h 42% \[\d{2}:\d{2}\]/);
     expect(output).toMatch(/7d 67% \[\d{2}:\d{2}\]/);
     expect(output).not.toContain('4200%');
     expect(output).not.toContain('6700%');
+  });
+
+  it('reset hint is computed from the injected `now`, not the wall clock', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 14, 23, 0, 0));
+
+    const injectedNow = new Date(2026, 3, 15, 14, 0, 0).getTime();
+    const resetsAt = new Date(2026, 3, 15, 15, 0, 0).toISOString();
+    const cache = makeCacheWithUsage(
+      {
+        extra_usage: { is_enabled: false },
+        five_hour: { utilization: 42, resets_at: resetsAt },
+        seven_day: { utilization: 67, resets_at: resetsAt },
+      } as Partial<UsageResponse>,
+      { lastUsageRefreshAt: injectedNow - 5 * 60 * 1000 },
+    );
+
+    const { output } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => injectedNow },
+    );
+
+    vi.useRealTimers();
+
+    expect(output).toContain('[15:00]');
+    expect(output).not.toMatch(/\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\b/);
   });
 
   it('renders placeholders when fallback buckets are null', async () => {


### PR DESCRIPTION
## What

`formatResetHint` was reading `Date.now()` directly, so the enterprise renderer's `Deps.now` injection never reached it. Tests asserting on reset-hint output were non-deterministic relative to the wall clock — discovered when `tests/render-enterprise.test.ts:396` failed locally because real time + 3h crossed midnight and a weekday prefix was added.

- `formatResetHint(resetsAt, now = Date.now())` — accept optional clock
- `render-enterprise` threads `nowMs` through `buildUsageSegment` → `buildFallbackUsageSegment` → `buildUsageBucketSegment`
- new unit test in `tests/format.test.ts` proves the formatter uses the injected `now` over wall clock
- new regression test in `tests/render-enterprise.test.ts` pins the wall clock at one time and injects a different `now`, asserting the renderer uses the injected value
- the original flaky test now uses fake timers so it's deterministic regardless of CI run time

`render-promax` is untouched: it has no clock-injection layer at all, the failing assertions were enterprise-only, and adding a `Deps.now` layer to promax is out of scope for the bug fix.

Closes #10

## Checklist

- [x] `npm test` passes — 293/293 (was 290/291 with one flaky)
- [x] `npm run typecheck` passes
- [x] Any changes in `credentials/`, `oauth/`, or `cache/` were discussed in the linked issue (n/a — none touched)