### PR TITLE
chore: release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nkootstra/cc-statusline",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nkootstra/cc-statusline",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "write-file-atomic": "^5.0.1"
@@ -22,7 +22,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nkootstra/cc-statusline",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Usage-aware Claude Code statusline + installer for Pro/Max and Enterprise users",
   "homepage": "https://github.com/nkootstra/cc-statusline#readme",
   "bugs": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/cli.ts'],
   format: ['cjs'],
-  target: 'node18',
+  target: 'node22',
   outDir: 'dist',
   outExtension: () => ({ js: '.cjs' }),
   minify: true,


### PR DESCRIPTION
## What

Minor version bump (`0.1.1` → `0.2.0`) plus a tooling tidy.

### Why minor, not patch

Since v0.1.1 we merged:
- #8 — GitHub Actions v4→v6 (CI tooling, invisible to users)
- #9 — `engines.node` `>=18` → `>=22`

The engines tightening is a **breaking change** for anyone installing on Node 18/20 (npm will refuse). In pre-1.0 semver the breaking slot is the minor, so `0.2.0`.

### Tooling tidy

`tsup.config.ts` still declared `target: 'node18'` even though Node 18 is no longer a supported runtime after #9. Bumping to `node22` so the build target matches the engines floor. Harmless before, but it would have left old syntax downlevels in the bundle for no reason.

### Changes

- `package.json` — `0.1.1` → `0.2.0`
- `package-lock.json` — version field regenerated via `npm install --package-lock-only`
- `tsup.config.ts` — `target: 'node18'` → `target: 'node22'`

No source changes. After merge, tag `v0.2.0` to trigger the release workflow → npm publish with provenance.

Closes #12

## Checklist

- [x] `npm test` passes — 293/293
- [x] `npm run typecheck` passes
- [x] Any changes in `credentials/`, `oauth/`, or `cache/` were discussed in the linked issue (n/a — none touched)