### PR TITLE
fix: resolve CodeQL medium alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/src/subcommands/init.ts
+++ b/src/subcommands/init.ts
@@ -219,7 +219,7 @@ async function writeInitialCache(
 
 /** Default refresh subprocess invoker. */
 function defaultSpawnRefresh(args: string[], opts: SpawnSyncOptions): SpawnRefreshResult {
-  return spawnSync(process.execPath, args, opts);
+  return spawnSync(process.execPath, args, { ...opts, shell: false });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -202,7 +202,7 @@ function buildMinimalEnv(): NodeJS.ProcessEnv {
 
 function defaultSpawnFn(): SpawnFn {
   return (command: string, args: string[], opts: SpawnOptions): void => {
-    const child = spawn(command, args, { ...opts, env: buildMinimalEnv() });
+    const child = spawn(command, args, { ...opts, env: buildMinimalEnv(), shell: false });
     if (process.platform !== 'win32') {
       child.unref();
     }


### PR DESCRIPTION
## What

Two CodeQL findings on \`main\`, both fixed without behaviour change.

### #2 — \`js/shell-command-injection-from-environment\` (medium)

\`src/subcommands/render-enterprise.ts:205\` — \`spawn\` defaulted to \`shell:false\` but didn't declare it. CodeQL traced \`process.execPath\` into the \`command\` arg and flagged it. Added explicit \`shell: false\` to \`defaultSpawnFn\`. Same pattern in \`src/subcommands/init.ts\` \`defaultSpawnRefresh\` was not flagged but didn't declare it either, so I added it there for consistency with the AGENTS.md invariant: _\"Every \`child_process.spawn\` call passes \`shell: false\` and an argv array.\"_

\`src/credentials/discover.ts\` already passed \`shell: false\` — unchanged.

### #1 — \`actions/missing-workflow-permissions\` (medium)

\`.github/workflows/ci.yml\` had no \`permissions:\` block, so the GITHUB_TOKEN inherited the repo default. CI only reads the repo (checkout → setup-node → npm ci → typecheck → build → test → bundle shebang verify), so \`contents: read\` is sufficient.

\`release.yml\` already declares explicit permissions (\`contents: read\`, \`id-token: write\`) and is unaffected.

Closes #14

## Checklist

- [x] \`npm test\` passes — 293/293
- [x] \`npm run typecheck\` passes
- [x] Any changes in \`credentials/\`, \`oauth/\`, or \`cache/\` were discussed in the linked issue (n/a — none touched)