### PR TITLE
fix(enterprise): reduce stale threshold to 60 s and fold session cost into monthly spend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Claude Code only runs custom statusline commands after the current workspace is 
 ## What you'll see
 
 - **Pro / Max**: model name plus colorized 5-hour and 7-day rate-limit utilization.
-- **Enterprise**: model name plus dollars-used / dollars-limit when monthly credits are enabled. Falls back to colorized 5-hour and 7-day rate-limit utilization.
+- **Enterprise**: model name plus dollars-used / dollars-limit when monthly credits are enabled. Falls back to colorized 5-hour and 7-day rate-limit utilization. The spend figure comes from a local cache that is refreshed in the background every 60 seconds; a ` ~` marker appears when the cached value is older than that. The trailing cost figure (e.g. `· $0.08`) is Claude Code's current-session token spend and updates independently.
 
 Pro and Max use the same renderer. They are separate installer choices only because Claude users know their subscription by those names; Claude Code exposes the same statusline usage fields for both.
 

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -24,7 +24,7 @@ import type { ExtraUsage, UsageBucket, UsageResponse } from '../oauth/types';
 // Constants
 // ---------------------------------------------------------------------------
 
-const STALE_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+const STALE_THRESHOLD_MS = 60 * 1000; // 60 seconds
 
 /** Remediation hint appended when authState is 'fatal'. Must be ≤ 50 chars. */
 export const AUTH_FATAL_HINT = ' re-run init to re-auth';
@@ -105,10 +105,6 @@ function buildCtxSegment(usedPercentage: number | null | undefined): string {
   return `ctx ${applyColor(`${pct}%`, tier)}`;
 }
 
-function buildCostSegment(totalCostUsd: number): string {
-  if (totalCostUsd === 0) return '';
-  return `$${totalCostUsd.toFixed(2)}`;
-}
 
 function buildUsageBucketSegment(
   label: string,
@@ -136,18 +132,20 @@ function hasCreditUsage(extra: ExtraUsage): extra is ExtraUsage & {
     extra.monthly_limit !== undefined;
 }
 
-function buildExtraUsageSegment(extra: ExtraUsage): string {
+function buildExtraUsageSegment(extra: ExtraUsage, sessionCostUsd: number): string {
   if (!hasCreditUsage(extra)) {
     return `usage ${MISSING}`;
   }
 
-  const usedDollars = (extra.used_credits / 100).toFixed(2);
-  const limitDollars = (extra.monthly_limit / 100).toFixed(2);
+  const combinedUsd = extra.used_credits / 100 + sessionCostUsd;
+  const limitUsd = extra.monthly_limit / 100;
+  const usedDisplay = combinedUsd.toFixed(2);
+  const limitDisplay = limitUsd.toFixed(2);
   const utilizationPct = Math.round(
-    extra.utilization ?? ((extra.used_credits / extra.monthly_limit) * 100),
+    limitUsd > 0 ? (combinedUsd / limitUsd) * 100 : 0,
   );
 
-  return `$${usedDollars} / $${limitDollars} (${utilizationPct}%)`;
+  return `$${usedDisplay} / $${limitDisplay} (${utilizationPct}%)`;
 }
 
 function buildFallbackUsageSegment(usage: UsageResponse, nowMs: number): string {
@@ -168,6 +166,7 @@ function buildUsageSegment(
   cache: Cache | null,
   isStale: boolean,
   nowMs: number,
+  sessionCostUsd: number,
 ): { text: string; isFetching: boolean } {
   if (cache === null || cache.usage === null) {
     return { text: `usage ${MISSING}${SEP}fetching…`, isFetching: true };
@@ -176,7 +175,7 @@ function buildUsageSegment(
   const usage = cache.usage;
   const extra = usage.extra_usage;
   let figureSeg = extra?.is_enabled === true
-    ? buildExtraUsageSegment(extra)
+    ? buildExtraUsageSegment(extra, sessionCostUsd)
     : buildFallbackUsageSegment(usage, nowMs);
 
   // Apply staleness dim + marker if needed.
@@ -223,10 +222,9 @@ function renderLine(
 
   const modelSeg = buildModelSegment(input.model.display_name);
   const ctxSeg = buildCtxSegment(input.context_window?.used_percentage);
-  const costSeg = buildCostSegment(input.cost.total_cost_usd);
 
-  // Build usage segment.
-  const { text: rawUsage, isFetching } = buildUsageSegment(cache, isStale, nowMs);
+  // Build usage segment, folding live session cost into the enterprise spend figure.
+  const { text: rawUsage, isFetching } = buildUsageSegment(cache, isStale, nowMs, input.cost.total_cost_usd);
 
   // Auth state overrides.
   let usageSeg = rawUsage;
@@ -259,12 +257,12 @@ function renderLine(
   const layout = chooseLayout(process.stdout.columns);
 
   if (layout === 'wide') {
-    return [modelSeg, ctxSeg, usageWithHint, costSeg].filter(Boolean).join(SEP) + '\n';
+    return [modelSeg, ctxSeg, usageWithHint].filter(Boolean).join(SEP) + '\n';
   }
 
   // Narrow: two lines.
   const row1 = [modelSeg, ctxSeg].filter(Boolean).join(SEP);
-  const row2 = [usageWithHint, costSeg].filter(Boolean).join(SEP);
+  const row2 = usageWithHint;
   return row1 + '\n' + row2 + '\n';
 }
 

--- a/tests/render-enterprise.test.ts
+++ b/tests/render-enterprise.test.ts
@@ -196,7 +196,7 @@ describe('golden Enterprise output', () => {
           monthly_limit: 100000,
         },
       },
-      { lastUsageRefreshAt: NOW - 5 * 60 * 1000 },
+      { lastUsageRefreshAt: NOW - 30 * 1000 },
     );
 
     const { output } = await runWithCache(cache, GOLDEN_STDIN, { now: () => NOW });
@@ -218,7 +218,7 @@ describe('golden Enterprise output', () => {
           resets_at: new Date(2026, 4, 5, 16, 22, 0).toISOString(),
         },
       },
-      { lastUsageRefreshAt: NOW - 5 * 60 * 1000 },
+      { lastUsageRefreshAt: NOW - 30 * 1000 },
     );
 
     const { output } = await runWithCache(cache, GOLDEN_STDIN, { now: () => NOW });
@@ -241,7 +241,7 @@ describe('Scenario 1 (AE2): happy path — extra_usage enabled, recent cache', (
   it('renders $780.00 / $1000.00 (78%) from usage-response.json', async () => {
     const NOW = Date.now();
     const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 5 * 60 * 1000, // 5 min ago — recent
+      lastUsageRefreshAt: NOW - 30 * 1000, // 30 s ago — recent
     });
 
     const { output, exitCode, spawnCalls } = await runWithCache(
@@ -258,7 +258,7 @@ describe('Scenario 1 (AE2): happy path — extra_usage enabled, recent cache', (
 
   it('output includes model name from stdin fixture', async () => {
     const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, { lastUsageRefreshAt: NOW - 1 * 60 * 1000 });
+    const cache = makeCacheWithUsage({}, { lastUsageRefreshAt: NOW - 30 * 1000 });
 
     const { output } = await runWithCache(
       cache,
@@ -298,11 +298,11 @@ describe('Scenario 1 (AE2): happy path — extra_usage enabled, recent cache', (
 // Scenario 2: Recent cache (14 min) — no spawn, no dim, no STALE_MARKER
 // ============================================================================
 
-describe('Scenario 2: recent cache (14 min) — no spawn fired, no stale markers', () => {
+describe('Scenario 2: recent cache (30 s) — no spawn fired, no stale markers', () => {
   it('does not spawn and does not append STALE_MARKER', async () => {
     const NOW = Date.now();
     const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 14 * 60 * 1000, // 14 min ago — within window
+      lastUsageRefreshAt: NOW - 30 * 1000, // 30 s ago — within window
     });
 
     const { output, spawnCalls } = await runWithCache(
@@ -1048,5 +1048,175 @@ describe('Scenario 20: minimal env — no secrets passed to spawn', () => {
     }
 
     expect(env['CLAUDE_CONFIG_DIR']).toBe('/my/claude');
+  });
+});
+
+// ============================================================================
+// Scenario 21: 60-second stale threshold (new behaviour)
+// ============================================================================
+
+describe('Scenario 21: stale threshold is 60 seconds', () => {
+  it('cache 61s old triggers spawn and STALE_MARKER', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 61 * 1000, // 61 s ago — just past threshold
+    });
+
+    const { output, spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(output).toContain(STALE_MARKER);
+  });
+
+  it('cache 59s old does NOT spawn and has no STALE_MARKER', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 59 * 1000, // 59 s ago — within threshold
+    });
+
+    const { output, spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(spawnCalls).toHaveLength(0);
+    expect(output).not.toContain(STALE_MARKER);
+  });
+});
+
+// ============================================================================
+// Scenario 22: session cost folded into enterprise monthly spend
+// ============================================================================
+
+function makeStdinWithCost(totalCostUsd: number): string {
+  return JSON.stringify({
+    session_id: 'cost-test',
+    transcript_path: '/t',
+    cwd: '/c',
+    model: { id: 'claude-sonnet-4-6', display_name: 'Sonnet 4.6' },
+    workspace: { current_dir: '/c', project_dir: '/c' },
+    version: '1',
+    output_style: { name: 'default' },
+    cost: {
+      total_cost_usd: totalCostUsd,
+      total_duration_ms: 0,
+      total_api_duration_ms: 0,
+      total_lines_added: 0,
+      total_lines_removed: 0,
+    },
+    exceeds_200k_tokens: false,
+    context_window: { used_percentage: null },
+  });
+}
+
+describe('Scenario 22: session cost folded into enterprise monthly spend', () => {
+  it('adds session cost to cached spent amount', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage(
+      {
+        extra_usage: {
+          is_enabled: true,
+          utilization: 0,
+          used_credits: 11, // $0.11 cached
+          monthly_limit: 20000, // $200.00
+        },
+      },
+      { lastUsageRefreshAt: NOW - 30 * 1000 },
+    );
+
+    const { output } = await runWithCache(
+      cache,
+      makeStdinWithCost(0.08), // $0.08 session cost
+      { now: () => NOW },
+    );
+
+    // Combined: $0.11 + $0.08 = $0.19
+    expect(output).toContain('$0.19 / $200.00');
+  });
+
+  it('zero session cost renders cached amount unchanged', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage(
+      {
+        extra_usage: {
+          is_enabled: true,
+          utilization: 78,
+          used_credits: 78000,
+          monthly_limit: 100000,
+        },
+      },
+      { lastUsageRefreshAt: NOW - 30 * 1000 },
+    );
+
+    const { output } = await runWithCache(
+      cache,
+      makeStdinWithCost(0),
+      { now: () => NOW },
+    );
+
+    expect(output).toContain('$780.00 / $1000.00');
+  });
+
+  it('utilisation percentage reflects combined amount', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage(
+      {
+        extra_usage: {
+          is_enabled: true,
+          utilization: 10, // will be recalculated
+          used_credits: 10000, // $100 cached, limit $1000 = 10%
+          monthly_limit: 100000,
+        },
+      },
+      { lastUsageRefreshAt: NOW - 30 * 1000 },
+    );
+
+    // Add $50 session cost → combined $150 / $1000 = 15%
+    const { output } = await runWithCache(
+      cache,
+      makeStdinWithCost(50),
+      { now: () => NOW },
+    );
+
+    expect(output).toContain('(15%)');
+    expect(output).not.toContain('(10%)');
+  });
+
+  it('trailing session cost segment is not rendered separately for enterprise', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage(
+      {
+        extra_usage: {
+          is_enabled: true,
+          utilization: 0,
+          used_credits: 11,
+          monthly_limit: 20000,
+        },
+      },
+      { lastUsageRefreshAt: NOW - 30 * 1000 },
+    );
+
+    const { output } = await runWithCache(
+      cache,
+      makeStdinWithCost(0.08),
+      { now: () => NOW },
+    );
+
+    // The combined amount should appear once; no separate trailing cost
+    const matches = output.match(/\$0\.\d+/g) ?? [];
+    // Only one $ figure group: the combined used/limit pair
+    // i.e. "$0.19 / $200.00 (0%)" — no extra "$0.08" at the end
+    expect(output).not.toMatch(/·\s+\$0\.08/);
   });
 });


### PR DESCRIPTION
## Summary

Enterprise monthly spend was cached for up to 15 minutes, so the displayed figure could be significantly behind reality. On top of that, the live session cost shown at the end of the line was a separate number rather than being part of the running total, making it easy to misread the total spend.

The cache now refreshes every 60 seconds. The per-session cost (`cost.total_cost_usd` from Claude Code stdin) is added to the cached `used_credits` figure before display, so the `$used / $limit (pct%)` segment reflects the true running total. The utilisation percentage is recomputed from the combined amount. The trailing session-cost segment is removed — it was redundant once folded in.

## What changed

| Area | Before | After |
|---|---|---|
| Stale threshold | 15 min | 60 s |
| Displayed spend | cached API value only | cached + live session cost |
| Utilisation % | API-provided field (stale) | recomputed from combined amount |
| Trailing cost segment | `· $0.08` at end of line | removed (folded into monthly spend) |

The dead `buildCostSegment` function was removed from `render-enterprise.ts` once the trailing segment was dropped.

## Tests

Scenario 21 anchors the new 60 s boundary: a 61 s old cache triggers spawn and STALE_MARKER; a 59 s old cache does not. Scenario 22 covers session-cost addition (`$0.11 + $0.08 → $0.19 / $200.00`), utilisation recalculation, and confirms no separate trailing segment appears.