### PR TITLE
fix(enterprise): separate monthly credits from session cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Claude Code only runs custom statusline commands after the current workspace is 
 ## What you'll see
 
 - **Pro / Max**: model name plus colorized 5-hour and 7-day rate-limit utilization.
-- **Enterprise**: model name plus dollars-used / dollars-limit when monthly credits are enabled. Falls back to colorized 5-hour and 7-day rate-limit utilization. The spend figure comes from a local cache that is refreshed in the background every 60 seconds; a ` ~` marker appears when the cached value is older than that. The trailing cost figure (e.g. `· $0.08`) is Claude Code's current-session token spend and updates independently.
+- **Enterprise**: model name plus cached monthly credits used / credits limit when monthly credits are enabled. Falls back to colorized 5-hour and 7-day rate-limit utilization. The credits figure comes from a local OAuth usage cache that is refreshed in the background every 60 seconds; a ` ~` marker appears when the cached value is older than that. When Claude Code reports a non-zero current-session cost, it appears separately as `session $...`; this is Claude Code's client-side estimate and may differ from actual billing.
 
 Pro and Max use the same renderer. They are separate installer choices only because Claude users know their subscription by those names; Claude Code exposes the same statusline usage fields for both.
 
@@ -28,7 +28,7 @@ Opus 4.7 · 5h 102% · 7d 81% [Tue 20:00]
 Example Enterprise output:
 
 ```text
-Opus 4.7 · $780.00 / $1000.00 (78%)
+Opus 4.7 · credits $780.00 / $1000.00 (78%) · session $0.08
 ```
 
 ## Check version

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -132,20 +132,25 @@ function hasCreditUsage(extra: ExtraUsage): extra is ExtraUsage & {
     extra.monthly_limit !== undefined;
 }
 
-function buildExtraUsageSegment(extra: ExtraUsage, sessionCostUsd: number): string {
+function buildSessionCostSegment(sessionCostUsd: number): string {
+  if (sessionCostUsd === 0) return '';
+  return `session $${sessionCostUsd.toFixed(2)}`;
+}
+
+function buildExtraUsageSegment(extra: ExtraUsage): string {
   if (!hasCreditUsage(extra)) {
     return `usage ${MISSING}`;
   }
 
-  const combinedUsd = extra.used_credits / 100 + sessionCostUsd;
+  const usedUsd = extra.used_credits / 100;
   const limitUsd = extra.monthly_limit / 100;
-  const usedDisplay = combinedUsd.toFixed(2);
+  const usedDisplay = usedUsd.toFixed(2);
   const limitDisplay = limitUsd.toFixed(2);
   const utilizationPct = Math.round(
-    limitUsd > 0 ? (combinedUsd / limitUsd) * 100 : 0,
+    limitUsd > 0 ? (usedUsd / limitUsd) * 100 : 0,
   );
 
-  return `$${usedDisplay} / $${limitDisplay} (${utilizationPct}%)`;
+  return `credits $${usedDisplay} / $${limitDisplay} (${utilizationPct}%)`;
 }
 
 function buildFallbackUsageSegment(usage: UsageResponse, nowMs: number): string {
@@ -175,12 +180,18 @@ function buildUsageSegment(
   const usage = cache.usage;
   const extra = usage.extra_usage;
   let figureSeg = extra?.is_enabled === true
-    ? buildExtraUsageSegment(extra, sessionCostUsd)
+    ? buildExtraUsageSegment(extra)
     : buildFallbackUsageSegment(usage, nowMs);
 
   // Apply staleness dim + marker if needed.
   if (isStale) {
     figureSeg = applyDim(figureSeg) + STALE_MARKER;
+  }
+
+  if (extra?.is_enabled === true) {
+    figureSeg = [figureSeg, buildSessionCostSegment(sessionCostUsd)]
+      .filter(Boolean)
+      .join(SEP);
   }
 
   return { text: figureSeg, isFetching: false };

--- a/tests/render-enterprise.test.ts
+++ b/tests/render-enterprise.test.ts
@@ -201,7 +201,7 @@ describe('golden Enterprise output', () => {
 
     const { output } = await runWithCache(cache, GOLDEN_STDIN, { now: () => NOW });
 
-    expect(output).toBe('Opus 4.7 · $780.00 / $1000.00 (78%)\n');
+    expect(output).toBe('Opus 4.7 · credits $780.00 / $1000.00 (78%)\n');
   });
 
   it('renders exact fallback bucket line', async () => {
@@ -1092,7 +1092,7 @@ describe('Scenario 21: stale threshold is 60 seconds', () => {
 });
 
 // ============================================================================
-// Scenario 22: session cost folded into enterprise monthly spend
+// Scenario 22: Enterprise credits and session cost stay source-separated
 // ============================================================================
 
 function makeStdinWithCost(totalCostUsd: number): string {
@@ -1116,8 +1116,8 @@ function makeStdinWithCost(totalCostUsd: number): string {
   });
 }
 
-describe('Scenario 22: session cost folded into enterprise monthly spend', () => {
-  it('adds session cost to cached spent amount', async () => {
+describe('Scenario 22: Enterprise credits and session cost stay source-separated', () => {
+  it('renders cached credits and live session estimate as separate segments', async () => {
     vi.stubEnv('NO_COLOR', '1');
     const NOW = Date.now();
     const cache = makeCacheWithUsage(
@@ -1125,8 +1125,8 @@ describe('Scenario 22: session cost folded into enterprise monthly spend', () =>
         extra_usage: {
           is_enabled: true,
           utilization: 0,
-          used_credits: 11, // $0.11 cached
-          monthly_limit: 20000, // $200.00
+          used_credits: 919, // $9.19 cached monthly credits
+          monthly_limit: 100000, // $1000.00
         },
       },
       { lastUsageRefreshAt: NOW - 30 * 1000 },
@@ -1134,12 +1134,13 @@ describe('Scenario 22: session cost folded into enterprise monthly spend', () =>
 
     const { output } = await runWithCache(
       cache,
-      makeStdinWithCost(0.08), // $0.08 session cost
+      makeStdinWithCost(16), // $16.00 live session estimate
       { now: () => NOW },
     );
 
-    // Combined: $0.11 + $0.08 = $0.19
-    expect(output).toContain('$0.19 / $200.00');
+    expect(output).toContain('credits $9.19 / $1000.00 (1%)');
+    expect(output).toContain('session $16.00');
+    expect(output).not.toContain('$25.19 / $1000.00');
   });
 
   it('zero session cost renders cached amount unchanged', async () => {
@@ -1164,9 +1165,10 @@ describe('Scenario 22: session cost folded into enterprise monthly spend', () =>
     );
 
     expect(output).toContain('$780.00 / $1000.00');
+    expect(output).not.toContain('session $0.00');
   });
 
-  it('utilisation percentage reflects combined amount', async () => {
+  it('utilisation percentage reflects cached credits only', async () => {
     vi.stubEnv('NO_COLOR', '1');
     const NOW = Date.now();
     const cache = makeCacheWithUsage(
@@ -1181,18 +1183,18 @@ describe('Scenario 22: session cost folded into enterprise monthly spend', () =>
       { lastUsageRefreshAt: NOW - 30 * 1000 },
     );
 
-    // Add $50 session cost → combined $150 / $1000 = 15%
     const { output } = await runWithCache(
       cache,
       makeStdinWithCost(50),
       { now: () => NOW },
     );
 
-    expect(output).toContain('(15%)');
-    expect(output).not.toContain('(10%)');
+    expect(output).toContain('credits $100.00 / $1000.00 (10%)');
+    expect(output).toContain('session $50.00');
+    expect(output).not.toContain('(15%)');
   });
 
-  it('trailing session cost segment is not rendered separately for enterprise', async () => {
+  it('renders session cost separately for enterprise', async () => {
     vi.stubEnv('NO_COLOR', '1');
     const NOW = Date.now();
     const cache = makeCacheWithUsage(
@@ -1213,10 +1215,32 @@ describe('Scenario 22: session cost folded into enterprise monthly spend', () =>
       { now: () => NOW },
     );
 
-    // The combined amount should appear once; no separate trailing cost
-    const matches = output.match(/\$0\.\d+/g) ?? [];
-    // Only one $ figure group: the combined used/limit pair
-    // i.e. "$0.19 / $200.00 (0%)" — no extra "$0.08" at the end
-    expect(output).not.toMatch(/·\s+\$0\.08/);
+    expect(output).toContain('credits $0.11 / $200.00');
+    expect(output).toMatch(/·\s+session \$0\.08/);
+    expect(output).not.toContain('$0.19 / $200.00');
+  });
+
+  it('applies stale marker only to cached credits when session cost is present', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage(
+      {
+        extra_usage: {
+          is_enabled: true,
+          used_credits: 919,
+          monthly_limit: 100000,
+        },
+      },
+      { lastUsageRefreshAt: NOW - 61 * 1000 },
+    );
+
+    const { output } = await runWithCache(
+      cache,
+      makeStdinWithCost(16),
+      { now: () => NOW },
+    );
+
+    expect(output).toContain('credits $9.19 / $1000.00 (1%) ~ · session $16.00');
+    expect(output).not.toContain('session $16.00 ~');
   });
 });


### PR DESCRIPTION
## Summary
Enterprise statuslines now keep cached monthly credits separate from Claude Code's live session-cost estimate, so the monthly utilization no longer implies those two different sources are one billing total.

This changes the Enterprise display to label cached OAuth usage as `credits $... / $... (%)` and append non-zero session estimates as `session $...`. The stale marker stays attached to the cached credits segment only.

## Tests
- Updated `tests/render-enterprise.test.ts` to cover separated credits/session rendering, zero-session omission, utilization based only on cached credits, and stale-marker placement.
- Verified locally with `npm run typecheck`, `npm run build`, and `npm test`.