### PR TITLE
feat(enterprise): rate-limit cooldown + doctor subcommand

### DIFF
--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -7,13 +7,14 @@ import type { OAuthCredentials, UsageResponse } from '../oauth/types';
 export type AuthState = 'ok' | 'fatal' | 'cloudflare-blocked';
 
 export interface Cache {
-  schemaVersion: 1;
+  schemaVersion: 2;
   authState: AuthState;
   credentials: OAuthCredentials;
   usage: UsageResponse | null;
   lastUsageRefreshAt: number;     // epoch ms; 0 means never
   lastRefreshStartedAt: number;   // epoch ms; 0 means none
   lastErrorMessage: string | null; // sanitized
+  rateLimitedUntilMs: number;     // epoch ms; 0 means not rate-limited
 }
 
 export function defaultCachePath(): string {
@@ -41,15 +42,30 @@ export function readCache(cachePath?: string): Cache | null {
     return null;
   }
 
-  if (
-    typeof parsed !== 'object' ||
-    parsed === null ||
-    (parsed as Record<string, unknown>)['schemaVersion'] !== 1
-  ) {
+  if (typeof parsed !== 'object' || parsed === null) {
     return null;
   }
 
-  return parsed as Cache;
+  const obj = parsed as Record<string, unknown>;
+  const version = obj['schemaVersion'];
+
+  if (version === 2) {
+    return parsed as Cache;
+  }
+
+  // v1 → v2: additive migration. v1 carried every field except rateLimitedUntilMs.
+  // Bumping cleanly per AGENTS.md (every shape change bumps the version) while
+  // preserving the user's tokens + usage across upgrade. Anything older or
+  // unrecognized falls through to null so init can rebuild.
+  if (version === 1) {
+    return {
+      ...(obj as Omit<Cache, 'schemaVersion' | 'rateLimitedUntilMs'>),
+      schemaVersion: 2,
+      rateLimitedUntilMs: 0,
+    };
+  }
+
+  return null;
 }
 
 export async function writeCache(cache: Cache, cachePath?: string): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { runUninstall } from './subcommands/uninstall';
 import { runRefresh } from './subcommands/refresh';
 import { runRenderPromax } from './subcommands/render-promax';
 import { runRenderEnterprise } from './subcommands/render-enterprise';
+import { runDoctor } from './subcommands/doctor';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const PKG_VERSION: string = ((): string => {
@@ -24,6 +25,7 @@ Usage:
   cc-statusline render-promax       (invoked by Claude Code; reads stdin)
   cc-statusline render-enterprise   (invoked by Claude Code; reads stdin)
   cc-statusline refresh             (background token + usage refresh)
+  cc-statusline doctor              (print cache diagnostics; no credentials)
   cc-statusline --version           (print the installed version)
 
 Pro and Max use the same renderer; Enterprise uses cache-backed OAuth usage.
@@ -54,6 +56,8 @@ async function main(argv: string[]): Promise<number> {
       return runRenderPromax();
     case 'render-enterprise':
       return runRenderEnterprise();
+    case 'doctor':
+      return runDoctor(argv.slice(3));
     case undefined:
     case '-h':
     case '--help':

--- a/src/oauth/client.ts
+++ b/src/oauth/client.ts
@@ -1,16 +1,38 @@
-import type { RefreshResult, FetchUsageResult, UsageResponse } from './types';
+import type { RefreshResult, FetchUsageResult, UsageResponse, RateLimitDiagnostics } from './types';
 
 const REFRESH_URL = 'https://platform.claude.com/v1/oauth/token';
 const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
 const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const BETA_HEADER = 'oauth-2025-04-20';
 const REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_RETRY_AFTER_SECONDS = 60;
 
-function parseRetryAfter(headers: Headers): number {
+function parseRetryAfter(headers: Headers): { seconds: number; present: boolean } {
   const value = headers.get('Retry-After');
-  if (value === null) return 60;
+  if (value === null) return { seconds: DEFAULT_RETRY_AFTER_SECONDS, present: false };
   const parsed = parseInt(value, 10);
-  return isFinite(parsed) && parsed > 0 ? parsed : 60;
+  if (!isFinite(parsed) || parsed <= 0) {
+    return { seconds: DEFAULT_RETRY_AFTER_SECONDS, present: false };
+  }
+  return { seconds: parsed, present: true };
+}
+
+function parseXShouldRetry(headers: Headers): boolean | null {
+  const value = headers.get('x-should-retry');
+  if (value === null) return null;
+  const lower = value.toLowerCase().trim();
+  if (lower === 'true') return true;
+  if (lower === 'false') return false;
+  return null;
+}
+
+function buildRateLimitDiagnostics(headers: Headers): RateLimitDiagnostics {
+  const { seconds, present } = parseRetryAfter(headers);
+  return {
+    retryAfterSeconds: seconds,
+    retryAfterPresent: present,
+    xShouldRetry: parseXShouldRetry(headers),
+  };
 }
 
 export async function refresh(
@@ -85,8 +107,7 @@ export async function refresh(
   }
 
   if (status === 429) {
-    const retryAfterSeconds = parseRetryAfter(response.headers);
-    return { kind: 'rate-limited', retryAfterSeconds };
+    return { kind: 'rate-limited', ...buildRateLimitDiagnostics(response.headers) };
   }
 
   if (status >= 500) {
@@ -137,8 +158,7 @@ export async function fetchUsage(
   }
 
   if (status === 429) {
-    const retryAfterSeconds = parseRetryAfter(response.headers);
-    return { kind: 'rate-limited', retryAfterSeconds };
+    return { kind: 'rate-limited', ...buildRateLimitDiagnostics(response.headers) };
   }
 
   if (status >= 500) {

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -25,16 +25,22 @@ export interface UsageResponse {
   extra_usage?: ExtraUsage;
 }
 
+export interface RateLimitDiagnostics {
+  retryAfterSeconds: number;
+  retryAfterPresent: boolean;
+  xShouldRetry: boolean | null;
+}
+
 export type RefreshResult =
   | { kind: 'success'; data: OAuthCredentials }
   | { kind: 'auth-fatal'; reason: string }
   | { kind: 'cloudflare-blocked'; status: number }
-  | { kind: 'rate-limited'; retryAfterSeconds: number }
+  | ({ kind: 'rate-limited' } & RateLimitDiagnostics)
   | { kind: 'transient'; status: number; message: string };
 
 export type FetchUsageResult =
   | { kind: 'success'; data: UsageResponse }
   | { kind: 'auth-fatal'; reason: string }
   | { kind: 'cloudflare-blocked'; status: number }
-  | { kind: 'rate-limited'; retryAfterSeconds: number }
+  | ({ kind: 'rate-limited' } & RateLimitDiagnostics)
   | { kind: 'transient'; status: number; message: string };

--- a/src/subcommands/doctor.ts
+++ b/src/subcommands/doctor.ts
@@ -1,0 +1,69 @@
+import { readCache, defaultCachePath, isRefreshInFlight } from '../cache/store';
+
+export interface DoctorDeps {
+  cachePath?: string;
+  now?: () => number;
+}
+
+function formatRelativeMs(ms: number): string {
+  const abs = Math.abs(ms);
+  if (abs < 1000) return `${ms}ms`;
+  const seconds = Math.round(abs / 1000);
+  if (seconds < 60) return ms < 0 ? `${seconds}s ago` : `in ${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return ms < 0 ? `${minutes}m ago` : `in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  return ms < 0 ? `${hours}h ago` : `in ${hours}h`;
+}
+
+export async function runDoctor(
+  _args: string[] = [],
+  deps: DoctorDeps = {},
+): Promise<number> {
+  const cachePath = deps.cachePath ?? defaultCachePath();
+  const now = deps.now ?? (() => Date.now());
+
+  const lines: string[] = ['cc-statusline doctor', ''];
+  lines.push(`cache path:    ${cachePath}`);
+
+  const cache = readCache(cachePath);
+
+  if (cache === null) {
+    lines.push('cache:         absent or unreadable');
+    lines.push('');
+    lines.push('Re-run `npx @nkootstra/cc-statusline --plan <pro|max|enterprise>` to install.');
+    process.stdout.write(lines.join('\n') + '\n');
+    return 0;
+  }
+
+  const nowMs = now();
+
+  lines.push(`cache:         present (schemaVersion ${cache.schemaVersion})`);
+  lines.push(`authState:     ${cache.authState}`);
+
+  const lastUsageLabel =
+    cache.lastUsageRefreshAt === 0
+      ? 'never'
+      : formatRelativeMs(cache.lastUsageRefreshAt - nowMs);
+  lines.push(`last usage:    ${lastUsageLabel}`);
+
+  const cooldownLabel =
+    cache.rateLimitedUntilMs > nowMs
+      ? `cooling down ${formatRelativeMs(cache.rateLimitedUntilMs - nowMs)}`
+      : 'not rate-limited';
+  lines.push(`rate limit:    ${cooldownLabel}`);
+
+  lines.push(`refresh:       ${isRefreshInFlight(cache, nowMs) ? 'in flight' : 'idle'}`);
+
+  // Token expiry without revealing the token itself.
+  const expiryLabel =
+    cache.credentials.expiresAt === 0
+      ? 'unknown'
+      : formatRelativeMs(cache.credentials.expiresAt - nowMs);
+  lines.push(`token expiry:  ${expiryLabel}`);
+
+  lines.push(`last error:    ${cache.lastErrorMessage ?? 'none'}`);
+
+  process.stdout.write(lines.join('\n') + '\n');
+  return 0;
+}

--- a/src/subcommands/init.ts
+++ b/src/subcommands/init.ts
@@ -206,13 +206,14 @@ async function writeInitialCache(
   cachePath: string,
 ): Promise<void> {
   const cache: Cache = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     authState: 'ok',
     credentials,
     usage: null,
     lastUsageRefreshAt: 0,
     lastRefreshStartedAt: 0,
     lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
   };
   await writeCache(cache, cachePath);
 }

--- a/src/subcommands/refresh.ts
+++ b/src/subcommands/refresh.ts
@@ -7,6 +7,18 @@ import {
   type Cache,
 } from '../cache/store';
 import { refresh, fetchUsage } from '../oauth/client';
+import type { RateLimitDiagnostics } from '../oauth/types';
+
+function formatRateLimitMessage(prefix: string, diag: RateLimitDiagnostics): string {
+  const headerNote = diag.retryAfterPresent
+    ? 'header present'
+    : 'header absent, default applied';
+  const shouldRetryNote =
+    diag.xShouldRetry === null
+      ? ''
+      : ` x-should-retry: ${diag.xShouldRetry ? 'true' : 'false'}.`;
+  return `${prefix} Retry-After: ${diag.retryAfterSeconds}s (${headerNote}).${shouldRetryNote}`;
+}
 
 export interface RefreshDeps {
   cachePath?: string;
@@ -31,6 +43,13 @@ export async function runRefresh(
 
     // Step 2: If authState is 'fatal' → exit 0 silently.
     if (initialCache.authState === 'fatal') {
+      return 0;
+    }
+
+    // Step 2b: If still in rate-limit cooldown → exit silently. The renderer
+    // also gates on this, but a stale install or a different code path could
+    // still fire refresh, so guard here too.
+    if (initialCache.rateLimitedUntilMs > now()) {
       return 0;
     }
 
@@ -100,10 +119,11 @@ export async function runRefresh(
 
         case 'rate-limited': {
           const msg = sanitizeErrorMessage(
-            `Token refresh rate-limited. Retry-After: ${result.retryAfterSeconds}s.`,
+            formatRateLimitMessage('Token refresh rate-limited.', result),
             cache.credentials,
           );
           cache.lastErrorMessage = msg;
+          cache.rateLimitedUntilMs = now() + result.retryAfterSeconds * 1000;
           await writeCache(cache, cachePath);
           return 0;
         }
@@ -155,10 +175,11 @@ export async function runRefresh(
 
       case 'rate-limited': {
         const msg = sanitizeErrorMessage(
-          `Usage fetch rate-limited. Retry-After: ${usageResult.retryAfterSeconds}s.`,
+          formatRateLimitMessage('Usage fetch rate-limited.', usageResult),
           cache.credentials,
         );
         cache.lastErrorMessage = msg;
+        cache.rateLimitedUntilMs = now() + usageResult.retryAfterSeconds * 1000;
         await writeCache(cache, cachePath);
         return 0;
       }
@@ -175,6 +196,7 @@ export async function runRefresh(
         cache.lastUsageRefreshAt = now();
         cache.lastErrorMessage = null;
         cache.authState = 'ok';
+        cache.rateLimitedUntilMs = 0;
         await writeCache(cache, cachePath);
         return 0;
       }

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -32,6 +32,18 @@ export const AUTH_FATAL_HINT = ' re-run init to re-auth';
 /** Hint appended when authState is 'cloudflare-blocked'. */
 export const CLOUDFLARE_HINT = ' refresh blocked (cloudflare); see README#cloudflare';
 
+/** Prefix for the rate-limit cooldown hint; followed by `Xm` / `Xs` until reset. */
+export const RATE_LIMITED_HINT_PREFIX = ' rate-limited; retry in ';
+
+function formatRateLimitedHint(msUntilReset: number): string {
+  const secondsRemaining = Math.max(1, Math.ceil(msUntilReset / 1000));
+  if (secondsRemaining < 60) {
+    return `${RATE_LIMITED_HINT_PREFIX}${secondsRemaining}s`;
+  }
+  const minutesRemaining = Math.ceil(secondsRemaining / 60);
+  return `${RATE_LIMITED_HINT_PREFIX}${minutesRemaining}m`;
+}
+
 // ---------------------------------------------------------------------------
 // Dependency injection
 // ---------------------------------------------------------------------------
@@ -260,6 +272,11 @@ function renderLine(
     } else if (cache.authState === 'cloudflare-blocked') {
       // Render normally; just append hint.
       authHint = CLOUDFLARE_HINT;
+    } else if (cache.rateLimitedUntilMs > nowMs) {
+      // Currently rate-limited (cooldown not yet elapsed). Render figures
+      // normally — they're still the most recent we know — but tell the user
+      // when retries will resume.
+      authHint = formatRateLimitedHint(cache.rateLimitedUntilMs - nowMs);
     }
   }
 
@@ -334,7 +351,10 @@ export async function runRenderEnterprise(
   // Don't fire if another refresh is already in flight.
   const inFlight = cache !== null && isRefreshInFlight(cache, nowMs);
 
-  const shouldFire = (cacheIsMissing || isStale) && !authFatal && !inFlight;
+  // Don't fire while in rate-limit cooldown — would just earn another 429.
+  const inCooldown = cache !== null && cache.rateLimitedUntilMs > nowMs;
+
+  const shouldFire = (cacheIsMissing || isStale) && !authFatal && !inFlight && !inCooldown;
 
   if (shouldFire) {
     const minimalEnv = buildMinimalEnv();

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -14,7 +14,7 @@ import type { OAuthCredentials } from '../src/oauth/types';
 
 function makeMinimalCache(overrides: Partial<Cache> = {}): Cache {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     authState: 'ok',
     credentials: {
       accessToken: 'sk-ant-access',
@@ -25,6 +25,7 @@ function makeMinimalCache(overrides: Partial<Cache> = {}): Cache {
     lastUsageRefreshAt: 0,
     lastRefreshStartedAt: 0,
     lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
     ...overrides,
   };
 }
@@ -77,9 +78,9 @@ describe('readCache', () => {
     }
   });
 
-  it('returns null when schemaVersion is not 1', () => {
+  it('returns null when schemaVersion is unrecognized', () => {
     const tmpFile = path.join(os.tmpdir(), `cc-statusline-test-${Date.now()}.json`);
-    fs.writeFileSync(tmpFile, JSON.stringify({ schemaVersion: 0, authState: 'ok' }), 'utf8');
+    fs.writeFileSync(tmpFile, JSON.stringify({ schemaVersion: 99, authState: 'ok' }), 'utf8');
     try {
       const result = readCache(tmpFile);
       expect(result).toBeNull();
@@ -88,16 +89,46 @@ describe('readCache', () => {
     }
   });
 
-  it('returns a typed Cache object for valid cache JSON', () => {
+  it('returns a typed Cache object for valid v2 JSON', () => {
     const cache = makeMinimalCache();
     const tmpFile = path.join(os.tmpdir(), `cc-statusline-test-${Date.now()}.json`);
     fs.writeFileSync(tmpFile, JSON.stringify(cache, null, 2) + '\n', 'utf8');
     try {
       const result = readCache(tmpFile);
       expect(result).not.toBeNull();
-      expect(result?.schemaVersion).toBe(1);
+      expect(result?.schemaVersion).toBe(2);
       expect(result?.authState).toBe('ok');
       expect(result?.credentials.accessToken).toBe('sk-ant-access');
+      expect(result?.rateLimitedUntilMs).toBe(0);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('migrates a v1 cache to v2 with rateLimitedUntilMs: 0', () => {
+    const v1Cache = {
+      schemaVersion: 1,
+      authState: 'ok',
+      credentials: {
+        accessToken: 'v1-access',
+        refreshToken: 'v1-refresh',
+        expiresAt: Date.now() + 3_600_000,
+      },
+      usage: null,
+      lastUsageRefreshAt: 12345,
+      lastRefreshStartedAt: 0,
+      lastErrorMessage: null,
+    };
+    const tmpFile = path.join(os.tmpdir(), `cc-statusline-v1-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(v1Cache, null, 2) + '\n', 'utf8');
+    try {
+      const result = readCache(tmpFile);
+      expect(result).not.toBeNull();
+      expect(result?.schemaVersion).toBe(2);
+      expect(result?.rateLimitedUntilMs).toBe(0);
+      // Other fields preserved
+      expect(result?.credentials.accessToken).toBe('v1-access');
+      expect(result?.lastUsageRefreshAt).toBe(12345);
     } finally {
       fs.unlinkSync(tmpFile);
     }
@@ -116,7 +147,7 @@ describe('writeCache', () => {
 
       const content = fs.readFileSync(filePath, 'utf8');
       const parsed = JSON.parse(content);
-      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.schemaVersion).toBe(2);
       expect(content.endsWith('\n')).toBe(true);
     } finally {
       fs.rmSync(tmpBase, { recursive: true, force: true });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runDoctor } from '../src/subcommands/doctor';
+import { writeCache, type Cache } from '../src/cache/store';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-doctor-test-'));
+}
+
+function cachePathOf(dir: string): string {
+  return path.join(dir, 'cache.json');
+}
+
+function makeCache(overrides: Partial<Cache> = {}): Cache {
+  return {
+    schemaVersion: 2,
+    authState: 'ok',
+    credentials: {
+      accessToken: 'sk-ant-secret-do-not-leak',
+      refreshToken: 'rt-secret-do-not-leak',
+      expiresAt: Date.now() + 3_600_000,
+    },
+    usage: null,
+    lastUsageRefreshAt: 0,
+    lastRefreshStartedAt: 0,
+    lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
+    ...overrides,
+  };
+}
+
+describe('runDoctor', () => {
+  let tmpDir: string;
+  let captured: string[];
+  let restoreStdout: () => void;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    captured = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    const spy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: unknown) => {
+        if (typeof chunk === 'string') captured.push(chunk);
+        else if (Buffer.isBuffer(chunk)) captured.push(chunk.toString('utf8'));
+        return true;
+      });
+    restoreStdout = () => {
+      spy.mockRestore();
+      void orig;
+    };
+  });
+
+  afterEach(() => {
+    restoreStdout();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('cache absent: prints helpful message and exits 0', async () => {
+    const exitCode = await runDoctor([], { cachePath: cachePathOf(tmpDir) });
+    expect(exitCode).toBe(0);
+    const output = captured.join('');
+    expect(output).toContain('absent');
+    expect(output).toContain('--plan');
+  });
+
+  it('cache present: surfaces authState, last usage, rate-limit status', async () => {
+    const now = Date.now();
+    const cache = makeCache({
+      authState: 'ok',
+      lastUsageRefreshAt: now - 30_000,
+      rateLimitedUntilMs: 0,
+    });
+    await writeCache(cache, cachePathOf(tmpDir));
+
+    const exitCode = await runDoctor([], {
+      cachePath: cachePathOf(tmpDir),
+      now: () => now,
+    });
+
+    expect(exitCode).toBe(0);
+    const output = captured.join('');
+    expect(output).toContain('authState:     ok');
+    expect(output).toContain('last usage:    30s ago');
+    expect(output).toContain('rate limit:    not rate-limited');
+  });
+
+  it('cooldown active: shows cooldown remaining', async () => {
+    const now = Date.now();
+    const cache = makeCache({
+      rateLimitedUntilMs: now + 4 * 60 * 1000,
+    });
+    await writeCache(cache, cachePathOf(tmpDir));
+
+    await runDoctor([], { cachePath: cachePathOf(tmpDir), now: () => now });
+    const output = captured.join('');
+    expect(output).toContain('cooling down');
+    expect(output).toMatch(/in \d+m/);
+  });
+
+  it('does NOT leak access or refresh token in output', async () => {
+    const now = Date.now();
+    const cache = makeCache({
+      lastErrorMessage: 'some error from earlier',
+    });
+    await writeCache(cache, cachePathOf(tmpDir));
+
+    await runDoctor([], { cachePath: cachePathOf(tmpDir), now: () => now });
+    const output = captured.join('');
+    expect(output).not.toContain('sk-ant-secret-do-not-leak');
+    expect(output).not.toContain('rt-secret-do-not-leak');
+  });
+
+  it('surfaces lastErrorMessage when set', async () => {
+    const now = Date.now();
+    const cache = makeCache({
+      lastErrorMessage:
+        'Usage fetch rate-limited. Retry-After: 120s (header present).',
+    });
+    await writeCache(cache, cachePathOf(tmpDir));
+
+    await runDoctor([], { cachePath: cachePathOf(tmpDir), now: () => now });
+    const output = captured.join('');
+    expect(output).toContain('header present');
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -71,13 +71,14 @@ const MOCK_USAGE: UsageResponse = {
 
 function makeValidCache(overrides: Partial<Cache> = {}): Cache {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     authState: 'ok',
     credentials: MOCK_CREDENTIALS,
     usage: MOCK_USAGE,
     lastUsageRefreshAt: Date.now(),
     lastRefreshStartedAt: 0,
     lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
     ...overrides,
   };
 }
@@ -855,21 +856,23 @@ describe('T22: initial cache shape', () => {
     });
     expect(code).toBe(0);
 
-    // Initial cache (before spawn) must have all six fields
+    // Initial cache (before spawn) must have all expected fields
     expect(initialCacheSnapshot).not.toBeNull();
     const c = initialCacheSnapshot!;
-    expect(c.schemaVersion).toBe(1);
+    expect(c.schemaVersion).toBe(2);
     expect(c.authState).toBe('ok');
     expect(c.credentials).toBeDefined();
     expect(c.usage).toBeNull();
     expect(c.lastUsageRefreshAt).toBe(0);
     expect(c.lastRefreshStartedAt).toBe(0);
     expect(c.lastErrorMessage).toBeNull();
+    expect(c.rateLimitedUntilMs).toBe(0);
 
     // None are undefined
     const fields: (keyof Cache)[] = [
       'schemaVersion', 'authState', 'credentials', 'usage',
       'lastUsageRefreshAt', 'lastRefreshStartedAt', 'lastErrorMessage',
+      'rateLimitedUntilMs',
     ];
     for (const field of fields) {
       expect(c[field]).not.toBeUndefined();

--- a/tests/oauth-client.test.ts
+++ b/tests/oauth-client.test.ts
@@ -94,7 +94,7 @@ describe('refresh', () => {
     expect(result.status).toBe(403);
   });
 
-  it('429 with Retry-After header -> rate-limited with that value', async () => {
+  it('429 with Retry-After header -> rate-limited with that value, retryAfterPresent: true', async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       makeResponse(429, '', { 'Retry-After': '60' }),
     );
@@ -102,14 +102,38 @@ describe('refresh', () => {
     expect(result.kind).toBe('rate-limited');
     if (result.kind !== 'rate-limited') return;
     expect(result.retryAfterSeconds).toBe(60);
+    expect(result.retryAfterPresent).toBe(true);
+    expect(result.xShouldRetry).toBeNull();
   });
 
-  it('429 without Retry-After header -> defaults to 60s', async () => {
+  it('429 without Retry-After header -> defaults to 60s, retryAfterPresent: false', async () => {
     const mockFetch = vi.fn().mockResolvedValue(makeResponse(429, ''));
     const result = await refresh('token', mockFetch);
     expect(result.kind).toBe('rate-limited');
     if (result.kind !== 'rate-limited') return;
     expect(result.retryAfterSeconds).toBe(60);
+    expect(result.retryAfterPresent).toBe(false);
+  });
+
+  it('429 with garbage Retry-After -> defaults to 60s, retryAfterPresent: false', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeResponse(429, '', { 'Retry-After': 'not-a-number' }),
+    );
+    const result = await refresh('token', mockFetch);
+    expect(result.kind).toBe('rate-limited');
+    if (result.kind !== 'rate-limited') return;
+    expect(result.retryAfterSeconds).toBe(60);
+    expect(result.retryAfterPresent).toBe(false);
+  });
+
+  it('429 with x-should-retry: false -> xShouldRetry: false', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeResponse(429, '', { 'Retry-After': '30', 'x-should-retry': 'false' }),
+    );
+    const result = await refresh('token', mockFetch);
+    expect(result.kind).toBe('rate-limited');
+    if (result.kind !== 'rate-limited') return;
+    expect(result.xShouldRetry).toBe(false);
   });
 
   it('500 -> transient with status 500', async () => {
@@ -212,7 +236,7 @@ describe('fetchUsage', () => {
     expect(result.status).toBe(403);
   });
 
-  it('429 with Retry-After header -> rate-limited', async () => {
+  it('429 with Retry-After header -> rate-limited with diagnostics', async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       makeResponse(429, '', { 'Retry-After': '120' }),
     );
@@ -220,14 +244,27 @@ describe('fetchUsage', () => {
     expect(result.kind).toBe('rate-limited');
     if (result.kind !== 'rate-limited') return;
     expect(result.retryAfterSeconds).toBe(120);
+    expect(result.retryAfterPresent).toBe(true);
+    expect(result.xShouldRetry).toBeNull();
   });
 
-  it('429 without Retry-After -> defaults to 60s', async () => {
+  it('429 without Retry-After -> defaults to 60s, retryAfterPresent: false', async () => {
     const mockFetch = vi.fn().mockResolvedValue(makeResponse(429, ''));
     const result = await fetchUsage('token', mockFetch);
     expect(result.kind).toBe('rate-limited');
     if (result.kind !== 'rate-limited') return;
     expect(result.retryAfterSeconds).toBe(60);
+    expect(result.retryAfterPresent).toBe(false);
+  });
+
+  it('429 with x-should-retry: false -> xShouldRetry: false', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeResponse(429, '', { 'Retry-After': '120', 'x-should-retry': 'false' }),
+    );
+    const result = await fetchUsage('token', mockFetch);
+    expect(result.kind).toBe('rate-limited');
+    if (result.kind !== 'rate-limited') return;
+    expect(result.xShouldRetry).toBe(false);
   });
 
   it('500 -> transient with status 500', async () => {

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -26,7 +26,7 @@ const MOCK_USAGE: UsageResponse = {
 function makeCache(overrides: Partial<Cache> = {}): Cache {
   const now = Date.now();
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     authState: 'ok',
     credentials: {
       accessToken: 'at-fresh-token',
@@ -37,6 +37,7 @@ function makeCache(overrides: Partial<Cache> = {}): Cache {
     lastUsageRefreshAt: 0,
     lastRefreshStartedAt: 0,
     lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
     ...overrides,
   };
 }
@@ -546,25 +547,25 @@ describe('runRefresh', () => {
   // -------------------------------------------------------------------------
   // Scenario 12: Rate-limited fetchUsage
   // -------------------------------------------------------------------------
-  it('12. rate-limited fetchUsage: lastErrorMessage mentions retry-after, authState stays ok', async () => {
-    const now = Date.now();
+  it('12. rate-limited fetchUsage: persists rateLimitedUntilMs, header-present note, authState stays ok', async () => {
+    const frozenNow = Date.now();
     const cache = makeCache({
       credentials: {
         accessToken: 'at-rl',
         refreshToken: 'rt-rl',
-        expiresAt: now + 60 * 60 * 1000, // fresh
+        expiresAt: frozenNow + 60 * 60 * 1000, // fresh
       },
     });
     await writeTestCache(tmpDir, cache);
 
     const mockFetch = buildFetchMock([
-      // fetchUsage returns 429
-      { status: 429, headers: { 'Retry-After': '60' } },
+      { status: 429, headers: { 'Retry-After': '120', 'x-should-retry': 'false' } },
     ]);
 
     const exitCode = await runRefresh([], {
       cachePath: cachePath(tmpDir),
       fetchImpl: mockFetch,
+      now: () => frozenNow,
     });
 
     expect(exitCode).toBe(0);
@@ -572,6 +573,92 @@ describe('runRefresh', () => {
     expect(result).not.toBeNull();
     expect(result!.authState).toBe('ok');
     expect(result!.lastErrorMessage).toMatch(/retry-after/i);
+    expect(result!.lastErrorMessage).toContain('header present');
+    expect(result!.lastErrorMessage).toContain('x-should-retry: false');
+    expect(result!.rateLimitedUntilMs).toBe(frozenNow + 120_000);
+  });
+
+  it('12b. rate-limited with header absent: lastErrorMessage notes default applied', async () => {
+    const frozenNow = Date.now();
+    const cache = makeCache({
+      credentials: {
+        accessToken: 'at-rl-no-header',
+        refreshToken: 'rt-rl-no-header',
+        expiresAt: frozenNow + 60 * 60 * 1000,
+      },
+    });
+    await writeTestCache(tmpDir, cache);
+
+    const mockFetch = buildFetchMock([
+      { status: 429 }, // no Retry-After
+    ]);
+
+    await runRefresh([], {
+      cachePath: cachePath(tmpDir),
+      fetchImpl: mockFetch,
+      now: () => frozenNow,
+    });
+
+    const result = readCache(cachePath(tmpDir));
+    expect(result!.lastErrorMessage).toContain('header absent, default applied');
+    expect(result!.rateLimitedUntilMs).toBe(frozenNow + 60_000);
+  });
+
+  it('12c. successful fetchUsage clears rateLimitedUntilMs', async () => {
+    const frozenNow = Date.now();
+    const cache = makeCache({
+      credentials: {
+        accessToken: 'at-recover',
+        refreshToken: 'rt-recover',
+        expiresAt: frozenNow + 60 * 60 * 1000,
+      },
+      rateLimitedUntilMs: frozenNow - 1000, // expired cooldown — refresh proceeds
+    });
+    await writeTestCache(tmpDir, cache);
+
+    const mockFetch = buildFetchMock([
+      { status: 200, body: MOCK_USAGE },
+    ]);
+
+    await runRefresh([], {
+      cachePath: cachePath(tmpDir),
+      fetchImpl: mockFetch,
+      now: () => frozenNow,
+    });
+
+    const result = readCache(cachePath(tmpDir));
+    expect(result!.rateLimitedUntilMs).toBe(0);
+    expect(result!.usage).toEqual(MOCK_USAGE);
+  });
+
+  it('12d. cooldown active: runRefresh exits without making any fetch call', async () => {
+    const frozenNow = Date.now();
+    const cache = makeCache({
+      credentials: {
+        accessToken: 'at-still-cooling',
+        refreshToken: 'rt-still-cooling',
+        expiresAt: frozenNow + 60 * 60 * 1000,
+      },
+      rateLimitedUntilMs: frozenNow + 60_000, // 60s of cooldown remaining
+    });
+    await writeTestCache(tmpDir, cache);
+
+    let fetchCalled = false;
+    const mockFetch: typeof fetch = async () => {
+      fetchCalled = true;
+      return new Response('', { status: 200 });
+    };
+
+    await runRefresh([], {
+      cachePath: cachePath(tmpDir),
+      fetchImpl: mockFetch,
+      now: () => frozenNow,
+    });
+
+    expect(fetchCalled).toBe(false);
+    // Cache untouched.
+    const result = readCache(cachePath(tmpDir));
+    expect(result!.rateLimitedUntilMs).toBe(frozenNow + 60_000);
   });
 
   // -------------------------------------------------------------------------

--- a/tests/render-enterprise.test.ts
+++ b/tests/render-enterprise.test.ts
@@ -54,13 +54,14 @@ const GOLDEN_STDIN = JSON.stringify({
 
 function makeCache(overrides: Partial<Cache> = {}): Cache {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     authState: 'ok',
     credentials: BASE_CREDENTIALS,
     usage: null,
     lastUsageRefreshAt: 0,
     lastRefreshStartedAt: 0,
     lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
     ...overrides,
   };
 }
@@ -122,7 +123,12 @@ function setTTY(value: boolean | undefined): void {
 // Import the function under test
 // ---------------------------------------------------------------------------
 
-import { runRenderEnterprise, AUTH_FATAL_HINT, CLOUDFLARE_HINT } from '../src/subcommands/render-enterprise';
+import {
+  runRenderEnterprise,
+  AUTH_FATAL_HINT,
+  CLOUDFLARE_HINT,
+  RATE_LIMITED_HINT_PREFIX,
+} from '../src/subcommands/render-enterprise';
 import { STALE_MARKER, MISSING } from '../src/statusline/format';
 import * as storeModule from '../src/cache/store';
 
@@ -1242,5 +1248,101 @@ describe('Scenario 22: Enterprise credits and session cost stay source-separated
 
     expect(output).toContain('credits $9.19 / $1000.00 (1%) ~ · session $16.00');
     expect(output).not.toContain('session $16.00 ~');
+  });
+});
+
+// ============================================================================
+// Scenario 23: rate-limit cooldown — no spawn fired, hint appended
+// ============================================================================
+
+describe('Scenario 23: rate-limit cooldown — no spawn, hint appended', () => {
+  it('does NOT spawn refresh when rateLimitedUntilMs is in the future', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 5 * 60 * 1000, // stale — would normally trigger spawn
+      rateLimitedUntilMs: NOW + 4 * 60 * 1000, // 4 min of cooldown remaining
+    });
+
+    const { spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('appends rate-limited hint with minutes remaining', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 30 * 1000,
+      rateLimitedUntilMs: NOW + 4 * 60 * 1000, // 4 min remaining
+    });
+
+    const { output } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(output).toContain(RATE_LIMITED_HINT_PREFIX.trim());
+    expect(output).toMatch(/retry in 4m/);
+  });
+
+  it('uses seconds for sub-minute cooldown', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 30 * 1000,
+      rateLimitedUntilMs: NOW + 30 * 1000, // 30s remaining
+    });
+
+    const { output } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(output).toMatch(/retry in 30s/);
+  });
+
+  it('does NOT show hint once cooldown has elapsed', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 30 * 1000,
+      rateLimitedUntilMs: NOW - 1, // just expired
+    });
+
+    const { output, spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(output).not.toContain(RATE_LIMITED_HINT_PREFIX.trim());
+    // Cache is recent (30s old), so still no spawn — that's fine.
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('cooldown hint takes precedence over no-hint when no auth issue', async () => {
+    // Sanity: hint must be present alongside the figures.
+    vi.stubEnv('NO_COLOR', '1');
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 30 * 1000,
+      rateLimitedUntilMs: NOW + 2 * 60 * 1000,
+    });
+
+    const { output } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(output).toContain('$780.00 / $1000.00 (78%)');
+    expect(output).toContain('retry in 2m');
   });
 });

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -71,7 +71,7 @@ function writeRenderer(dir: string): void {
 
 async function writeTestCache(dir: string): Promise<void> {
   const cache: Cache = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     authState: 'ok',
     credentials: {
       accessToken: 'sk-ant-test',
@@ -85,6 +85,7 @@ async function writeTestCache(dir: string): Promise<void> {
     lastUsageRefreshAt: Date.now(),
     lastRefreshStartedAt: 0,
     lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
   };
   await writeCache(cache, getCachePath(dir));
 }


### PR DESCRIPTION
## Summary
- Persist a rate-limit cooldown on the cache and gate `refresh` spawns + render polling on it; the Enterprise statusline now shows `rate-limited; retry in Xm` instead of silently going stale. Cache `schemaVersion` 1 → 2 with an in-memory v1 → v2 migration so existing installs keep working without re-running `init`.
- `parseRetryAfter` now returns whether the `Retry-After` header was actually present, and we capture `x-should-retry`. Both are folded into `lastErrorMessage` (sanitized) so we can confirm what Anthropic is sending in the wild before tuning the default fallback.
- New `cc-statusline doctor` subcommand prints cache state (authState, last usage relative time, cooldown, refresh in-flight, token expiry, last error) without revealing token bytes — replaces having to `cat cache.json` to debug.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds, bundle 36.77 KB (under cold-start budget)
- [x] `npm test` — 317/317 across 13 files, including 5 new doctor tests, cooldown coverage in refresh + render-enterprise + oauth-client + cache-store, and a v1 → v2 migration test
- [x] Local install (`--plan max`) refreshes the bundle in `~/.claude/cc-statusline/`; `doctor` correctly reports "absent" since Max doesn't keep an OAuth cache; `render-promax` smoke-tested with sample stdin
- [x] Help output includes the new `doctor` line; unknown command still exits 1 with HELP