### PR TITLE
fix(diagnostics): add rate-limit investigation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ Removes the statusline entry from `~/.claude/settings.json` and deletes the inst
 
 cc-statusline reads Claude Code's stored OAuth credential (macOS keychain or `~/.claude/.credentials.json`) once at install and copies it to `~/.claude/cc-statusline/cache.json` (mode `0600`). This file is rewritten as the token rotates. Compromise of your home directory exposes the same tokens Claude Code already exposes there.
 
+## Credentials and investigation
+
+During `init`, automatic credential discovery uses this order:
+
+1. macOS Keychain service `Claude Code-credentials` (macOS only)
+2. `~/.claude/.credentials.json`
+3. `~/.claude/credentials.json`
+
+`--credentials-path=<path>` overrides automatic discovery. The discovered OAuth envelope contains an `accessToken`, a `refreshToken`, and an expiry time. cc-statusline copies those values into its local cache and uses that cache for subsequent requests. The cache is located at `~/.claude/cc-statusline/cache.json`, or under `$CLAUDE_CONFIG_DIR/cc-statusline/cache.json` when `CLAUDE_CONFIG_DIR` is set.
+
+The `accessToken` is sent as a Bearer token to the usage endpoint. The `refreshToken` is sent to the OAuth token endpoint only when the access token is close to expiry; rotated credentials are then written back to the local cache. Reinstalling with `--force` can therefore replace the local cache with credentials rediscovered from the original source.
+
+`cc-statusline doctor` reports that API calls use the local cache. Current cache versions do not retain whether the cache was originally populated from Keychain, a credentials file, or `--credentials-path`, so `doctor` reports that origin as “not recorded.” The statusline’s diagnostics also cannot observe Claude Code or another application using the same account or OAuth credential; server-side/account-level evidence would be required for that.
+
+## Diagnostics
+
+Enterprise refresh decisions and OAuth request outcomes are recorded in a bounded, token-free JSONL log at `~/.claude/cc-statusline/debug.log`. To print the current cache state and retained diagnostic history, run:
+
+```bash
+cc-statusline doctor --logs
+```
+
+The log records endpoint labels, response status, request duration, refresh decisions, and rate-limit cooldown details. It never records access tokens, refresh tokens, authorization headers, or response bodies.
+
 ## Release
 
 Releases are published to npm as `@nkootstra/cc-statusline` from version tags (`v*`) through the GitHub Actions release workflow. The installed executable remains `cc-statusline`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ Usage:
   cc-statusline render-promax       (invoked by Claude Code; reads stdin)
   cc-statusline render-enterprise   (invoked by Claude Code; reads stdin)
   cc-statusline refresh             (background token + usage refresh)
-  cc-statusline doctor              (print cache diagnostics; no credentials)
+  cc-statusline doctor [--logs]     (print cache diagnostics; no credentials)
   cc-statusline --version           (print the installed version)
 
 Pro and Max use the same renderer; Enterprise uses cache-backed OAuth usage.
@@ -71,9 +71,9 @@ async function main(argv: string[]): Promise<number> {
 
 main(process.argv)
   .then((code) => {
-    process.exit(code);
+    process.exitCode = code;
   })
   .catch((err) => {
     process.stderr.write(`cc-statusline crashed: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
+    process.exitCode = 1;
   });

--- a/src/diagnostics/logger.ts
+++ b/src/diagnostics/logger.ts
@@ -1,0 +1,76 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+export const MAX_DIAGNOSTIC_LOG_BYTES = 256 * 1024;
+
+export interface DiagnosticLoggerOptions {
+  now?: () => number;
+  pid?: number;
+}
+
+export interface DiagnosticLogger {
+  log(details: Record<string, unknown>): Promise<void>;
+}
+
+export function defaultDiagnosticLogPath(cachePath: string): string {
+  return path.join(path.dirname(cachePath), 'debug.log');
+}
+
+async function rotateIfNeeded(logPath: string, nextLineBytes: number): Promise<void> {
+  let currentSize = 0;
+  try {
+    currentSize = (await fs.stat(logPath)).size;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  if (currentSize === 0 || currentSize + nextLineBytes <= MAX_DIAGNOSTIC_LOG_BYTES) {
+    return;
+  }
+
+  const rotatedPath = `${logPath}.1`;
+  await fs.rm(rotatedPath, { force: true });
+  await fs.rename(logPath, rotatedPath);
+}
+
+export function createDiagnosticLogger(
+  logPath: string,
+  options: DiagnosticLoggerOptions = {},
+): DiagnosticLogger {
+  const now = options.now ?? (() => Date.now());
+  const pid = options.pid ?? process.pid;
+
+  return {
+    async log(details: Record<string, unknown>): Promise<void> {
+      try {
+        const event = {
+          timestamp: new Date(now()).toISOString(),
+          pid,
+          ...details,
+        };
+        const line = JSON.stringify(event) + '\n';
+        const lineBytes = Buffer.byteLength(line, 'utf8');
+
+        await fs.mkdir(path.dirname(logPath), { recursive: true, mode: 0o700 });
+        await rotateIfNeeded(logPath, lineBytes);
+        await fs.appendFile(logPath, line, { encoding: 'utf8', mode: 0o600 });
+        await fs.chmod(logPath, 0o600);
+      } catch {
+        // Diagnostics must never change the statusline or refresh outcome.
+      }
+    },
+  };
+}
+
+async function readIfPresent(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return '';
+    return '';
+  }
+}
+
+export async function readDiagnosticLog(logPath: string): Promise<string> {
+  return (await readIfPresent(`${logPath}.1`)) + (await readIfPresent(logPath));
+}

--- a/src/diagnostics/logger.ts
+++ b/src/diagnostics/logger.ts
@@ -1,7 +1,11 @@
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 export const MAX_DIAGNOSTIC_LOG_BYTES = 256 * 1024;
+const LOCK_TIMEOUT_MS = 200;
+const LOCK_RETRY_MS = 10;
+const LOCK_STALE_MS = 5_000;
 
 export interface DiagnosticLoggerOptions {
   now?: () => number;
@@ -14,6 +18,78 @@ export interface DiagnosticLogger {
 
 export function defaultDiagnosticLogPath(cachePath: string): string {
   return path.join(path.dirname(cachePath), 'debug.log');
+}
+
+export function defaultDiagnosticLogLockPath(logPath: string): string {
+  const safe = Buffer.from(logPath).toString('hex');
+  return path.join(os.tmpdir(), 'cc-statusline-diagnostics', `${safe}.lock`);
+}
+
+export function defaultDiagnosticLogDisabledPath(logPath: string): string {
+  return `${logPath}.disabled`;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    return false;
+  }
+}
+
+async function cleanupStaleLock(lockPath: string): Promise<void> {
+  try {
+    const stat = await fs.stat(lockPath);
+    if (Date.now() - stat.mtimeMs <= LOCK_STALE_MS) return;
+    await fs.rm(lockPath, { force: true, recursive: true });
+  } catch {
+    // Stale lock cleanup is best-effort.
+  }
+}
+
+export async function withDiagnosticLogLock<T>(
+  logPath: string,
+  action: () => Promise<T>,
+): Promise<T | undefined> {
+  const logDir = path.dirname(logPath);
+  if (!(await exists(logDir))) return undefined;
+
+  const lockPath = defaultDiagnosticLogLockPath(logPath);
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  while (true) {
+    try {
+      await fs.mkdir(lockPath, { mode: 0o700, recursive: true });
+      break;
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EEXIST') {
+        if (Date.now() > deadline) {
+          await cleanupStaleLock(lockPath);
+        }
+        await sleep(LOCK_RETRY_MS);
+        continue;
+      }
+      if (code === 'ENOENT') {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  try {
+    return await action();
+  } finally {
+    await fs.rm(lockPath, { force: true, recursive: true });
+  }
 }
 
 async function rotateIfNeeded(logPath: string, nextLineBytes: number): Promise<void> {
@@ -30,7 +106,11 @@ async function rotateIfNeeded(logPath: string, nextLineBytes: number): Promise<v
 
   const rotatedPath = `${logPath}.1`;
   await fs.rm(rotatedPath, { force: true });
-  await fs.rename(logPath, rotatedPath);
+  try {
+    await fs.rename(logPath, rotatedPath);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
 }
 
 export function createDiagnosticLogger(
@@ -39,6 +119,8 @@ export function createDiagnosticLogger(
 ): DiagnosticLogger {
   const now = options.now ?? (() => Date.now());
   const pid = options.pid ?? process.pid;
+  const disabledPath = defaultDiagnosticLogDisabledPath(logPath);
+  const logDir = path.dirname(logPath);
 
   return {
     async log(details: Record<string, unknown>): Promise<void> {
@@ -51,10 +133,17 @@ export function createDiagnosticLogger(
         const line = JSON.stringify(event) + '\n';
         const lineBytes = Buffer.byteLength(line, 'utf8');
 
-        await fs.mkdir(path.dirname(logPath), { recursive: true, mode: 0o700 });
-        await rotateIfNeeded(logPath, lineBytes);
-        await fs.appendFile(logPath, line, { encoding: 'utf8', mode: 0o600 });
-        await fs.chmod(logPath, 0o600);
+        if (!(await exists(logDir))) return;
+        if (await exists(disabledPath)) return;
+
+        await withDiagnosticLogLock(logPath, async () => {
+          if (!(await exists(logDir))) return;
+          if (await exists(disabledPath)) return;
+
+          await rotateIfNeeded(logPath, lineBytes);
+          await fs.appendFile(logPath, line, { encoding: 'utf8', mode: 0o600 });
+          await fs.chmod(logPath, 0o600);
+        });
       } catch {
         // Diagnostics must never change the statusline or refresh outcome.
       }

--- a/src/subcommands/doctor.ts
+++ b/src/subcommands/doctor.ts
@@ -1,7 +1,12 @@
 import { readCache, defaultCachePath, isRefreshInFlight } from '../cache/store';
+import {
+  defaultDiagnosticLogPath,
+  readDiagnosticLog,
+} from '../diagnostics/logger';
 
 export interface DoctorDeps {
   cachePath?: string;
+  logPath?: string;
   now?: () => number;
 }
 
@@ -17,11 +22,13 @@ function formatRelativeMs(ms: number): string {
 }
 
 export async function runDoctor(
-  _args: string[] = [],
+  args: string[] = [],
   deps: DoctorDeps = {},
 ): Promise<number> {
   const cachePath = deps.cachePath ?? defaultCachePath();
+  const logPath = deps.logPath ?? defaultDiagnosticLogPath(cachePath);
   const now = deps.now ?? (() => Date.now());
+  const showLogs = args.includes('--logs');
 
   const lines: string[] = ['cc-statusline doctor', ''];
   lines.push(`cache path:    ${cachePath}`);
@@ -30,6 +37,13 @@ export async function runDoctor(
 
   if (cache === null) {
     lines.push('cache:         absent or unreadable');
+    lines.push('credential use: unavailable (cache absent)');
+    lines.push('credential origin: not recorded');
+    lines.push(`diagnostics:   ${logPath}`);
+    if (showLogs) {
+      const log = await readDiagnosticLog(logPath);
+      if (log.length > 0) lines.push('', log.trimEnd());
+    }
     lines.push('');
     lines.push('Re-run `npx @nkootstra/cc-statusline --plan <pro|max|enterprise>` to install.');
     process.stdout.write(lines.join('\n') + '\n');
@@ -40,6 +54,8 @@ export async function runDoctor(
 
   lines.push(`cache:         present (schemaVersion ${cache.schemaVersion})`);
   lines.push(`authState:     ${cache.authState}`);
+  lines.push('credential use: local cache (cache.json)');
+  lines.push('credential origin: not recorded');
 
   const lastUsageLabel =
     cache.lastUsageRefreshAt === 0
@@ -63,6 +79,12 @@ export async function runDoctor(
   lines.push(`token expiry:  ${expiryLabel}`);
 
   lines.push(`last error:    ${cache.lastErrorMessage ?? 'none'}`);
+  lines.push(`diagnostics:   ${logPath}`);
+
+  if (showLogs) {
+    const log = await readDiagnosticLog(logPath);
+    lines.push('', log.length > 0 ? log.trimEnd() : '(no diagnostic events)');
+  }
 
   process.stdout.write(lines.join('\n') + '\n');
   return 0;

--- a/src/subcommands/refresh.ts
+++ b/src/subcommands/refresh.ts
@@ -7,7 +7,16 @@ import {
   type Cache,
 } from '../cache/store';
 import { refresh, fetchUsage } from '../oauth/client';
-import type { RateLimitDiagnostics } from '../oauth/types';
+import {
+  createDiagnosticLogger,
+  defaultDiagnosticLogPath,
+  type DiagnosticLogger,
+} from '../diagnostics/logger';
+import type {
+  FetchUsageResult,
+  RateLimitDiagnostics,
+  RefreshResult,
+} from '../oauth/types';
 
 function formatRateLimitMessage(prefix: string, diag: RateLimitDiagnostics): string {
   const headerNote = diag.retryAfterPresent
@@ -22,8 +31,51 @@ function formatRateLimitMessage(prefix: string, diag: RateLimitDiagnostics): str
 
 export interface RefreshDeps {
   cachePath?: string;
+  logPath?: string;
   fetchImpl?: typeof fetch;
   now?: () => number;
+}
+
+type RequestEndpoint = 'token' | 'usage';
+type RequestResult = RefreshResult | FetchUsageResult;
+
+function statusForResult(endpoint: RequestEndpoint, result: RequestResult): number | undefined {
+  if (result.kind === 'success') return 200;
+  if (result.kind === 'rate-limited') return 429;
+  if (result.kind === 'auth-fatal') {
+    if (result.reason === '401') return 401;
+    if (endpoint === 'token' && result.reason === 'invalid_grant') return 400;
+    return undefined;
+  }
+  return result.status;
+}
+
+async function logRequestResult(
+  logger: DiagnosticLogger,
+  endpoint: RequestEndpoint,
+  result: RequestResult,
+  durationMs: number,
+  credentials: Cache['credentials'],
+): Promise<void> {
+  const details: Record<string, unknown> = {
+    event: 'http.result',
+    endpoint,
+    result: result.kind,
+    status: statusForResult(endpoint, result),
+    durationMs,
+  };
+
+  if (result.kind === 'rate-limited') {
+    details['retryAfterSeconds'] = result.retryAfterSeconds;
+    details['retryAfterPresent'] = result.retryAfterPresent;
+    details['xShouldRetry'] = result.xShouldRetry;
+  } else if (result.kind === 'transient') {
+    details['error'] = sanitizeErrorMessage(result.message, credentials);
+  } else if (result.kind === 'auth-fatal') {
+    details['reason'] = sanitizeErrorMessage(result.reason, credentials);
+  }
+
+  await logger.log(details);
 }
 
 export async function runRefresh(
@@ -31,18 +83,22 @@ export async function runRefresh(
   deps: RefreshDeps = {},
 ): Promise<number> {
   const cachePath = deps.cachePath ?? defaultCachePath();
+  const logPath = deps.logPath ?? defaultDiagnosticLogPath(cachePath);
   const fetchImpl = deps.fetchImpl;
   const now = deps.now ?? (() => Date.now());
+  const logger = createDiagnosticLogger(logPath, { now });
 
   try {
     // Step 1: Read cache. If null → exit 0 silently.
     const initialCache = readCache(cachePath);
     if (initialCache === null) {
+      await logger.log({ event: 'refresh.skipped', reason: 'cache-missing' });
       return 0;
     }
 
     // Step 2: If authState is 'fatal' → exit 0 silently.
     if (initialCache.authState === 'fatal') {
+      await logger.log({ event: 'refresh.skipped', reason: 'auth-fatal' });
       return 0;
     }
 
@@ -50,6 +106,11 @@ export async function runRefresh(
     // also gates on this, but a stale install or a different code path could
     // still fire refresh, so guard here too.
     if (initialCache.rateLimitedUntilMs > now()) {
+      await logger.log({
+        event: 'refresh.skipped',
+        reason: 'rate-limit-cooldown',
+        cooldownRemainingMs: initialCache.rateLimitedUntilMs - now(),
+      });
       return 0;
     }
 
@@ -61,6 +122,7 @@ export async function runRefresh(
     }
 
     if (isRefreshInFlight(casCache, now())) {
+      await logger.log({ event: 'refresh.skipped', reason: 'in-flight' });
       return 0;
     }
 
@@ -76,11 +138,13 @@ export async function runRefresh(
       verifyCache.lastRefreshStartedAt !== startedAt
     ) {
       // Another process overwrote our write; exit silently.
+      await logger.log({ event: 'refresh.skipped', reason: 'cas-lost' });
       return 0;
     }
 
     // Work with a mutable copy of the verified cache.
     let cache: Cache = verifyCache;
+    await logger.log({ event: 'refresh.started' });
 
     // Step 4: Token refresh decision.
     const FIVE_MINUTES_MS = 5 * 60 * 1000;
@@ -88,10 +152,24 @@ export async function runRefresh(
 
     if (cache.credentials.expiresAt - now() < FIVE_MINUTES_MS) {
       // Token is near expiry or already expired — refresh it.
+      await logger.log({
+        event: 'token.refresh.decision',
+        action: 'refresh',
+        expiresInMs: cache.credentials.expiresAt - now(),
+      });
       const refreshArgs: Parameters<typeof refresh> = fetchImpl
         ? [cache.credentials.refreshToken, fetchImpl]
         : [cache.credentials.refreshToken];
+      await logger.log({ event: 'http.request', endpoint: 'token' });
+      const requestStartedAt = performance.now();
       const result = await refresh(...refreshArgs);
+      await logRequestResult(
+        logger,
+        'token',
+        result,
+        Math.round(performance.now() - requestStartedAt),
+        cache.credentials,
+      );
 
       switch (result.kind) {
         case 'auth-fatal': {
@@ -102,6 +180,7 @@ export async function runRefresh(
           cache.authState = 'fatal';
           cache.lastErrorMessage = msg;
           await writeCache(cache, cachePath);
+          await logger.log({ event: 'refresh.completed', outcome: 'auth-fatal' });
           return 0;
         }
 
@@ -114,6 +193,7 @@ export async function runRefresh(
           cache.authState = 'cloudflare-blocked';
           cache.lastErrorMessage = msg;
           await writeCache(cache, cachePath);
+          await logger.log({ event: 'refresh.completed', outcome: 'cloudflare-blocked' });
           return 0;
         }
 
@@ -125,6 +205,11 @@ export async function runRefresh(
           cache.lastErrorMessage = msg;
           cache.rateLimitedUntilMs = now() + result.retryAfterSeconds * 1000;
           await writeCache(cache, cachePath);
+          await logger.log({
+            event: 'refresh.completed',
+            outcome: 'rate-limited',
+            cooldownUntilMs: cache.rateLimitedUntilMs,
+          });
           return 0;
         }
 
@@ -132,6 +217,7 @@ export async function runRefresh(
           const msg = sanitizeErrorMessage(result.message, cache.credentials);
           cache.lastErrorMessage = msg;
           await writeCache(cache, cachePath);
+          await logger.log({ event: 'refresh.completed', outcome: 'transient' });
           return 0;
         }
 
@@ -141,13 +227,24 @@ export async function runRefresh(
           break;
         }
       }
+    } else {
+      await logger.log({ event: 'token.refresh.decision', action: 'skip', reason: 'token-fresh' });
     }
 
     // Step 5: Fetch usage.
     const usageArgs: Parameters<typeof fetchUsage> = fetchImpl
       ? [cache.credentials.accessToken, fetchImpl]
       : [cache.credentials.accessToken];
+    await logger.log({ event: 'http.request', endpoint: 'usage' });
+    const usageRequestStartedAt = performance.now();
     const usageResult = await fetchUsage(...usageArgs);
+    await logRequestResult(
+      logger,
+      'usage',
+      usageResult,
+      Math.round(performance.now() - usageRequestStartedAt),
+      cache.credentials,
+    );
 
     switch (usageResult.kind) {
       case 'auth-fatal': {
@@ -158,6 +255,7 @@ export async function runRefresh(
         cache.authState = 'fatal';
         cache.lastErrorMessage = msg;
         await writeCache(cache, cachePath);
+        await logger.log({ event: 'refresh.completed', outcome: 'auth-fatal' });
         return 0;
       }
 
@@ -170,6 +268,7 @@ export async function runRefresh(
         cache.authState = 'cloudflare-blocked';
         cache.lastErrorMessage = msg;
         await writeCache(cache, cachePath);
+        await logger.log({ event: 'refresh.completed', outcome: 'cloudflare-blocked' });
         return 0;
       }
 
@@ -181,6 +280,11 @@ export async function runRefresh(
         cache.lastErrorMessage = msg;
         cache.rateLimitedUntilMs = now() + usageResult.retryAfterSeconds * 1000;
         await writeCache(cache, cachePath);
+        await logger.log({
+          event: 'refresh.completed',
+          outcome: 'rate-limited',
+          cooldownUntilMs: cache.rateLimitedUntilMs,
+        });
         return 0;
       }
 
@@ -188,6 +292,7 @@ export async function runRefresh(
         const msg = sanitizeErrorMessage(usageResult.message, cache.credentials);
         cache.lastErrorMessage = msg;
         await writeCache(cache, cachePath);
+        await logger.log({ event: 'refresh.completed', outcome: 'transient' });
         return 0;
       }
 
@@ -198,6 +303,7 @@ export async function runRefresh(
         cache.authState = 'ok';
         cache.rateLimitedUntilMs = 0;
         await writeCache(cache, cachePath);
+        await logger.log({ event: 'refresh.completed', outcome: 'success' });
         return 0;
       }
     }
@@ -205,6 +311,7 @@ export async function runRefresh(
     // Catastrophic uncaught error — swallow and exit 0 to be spawn-friendly.
     // This path is a last resort; the code above should handle all known cases.
     void err;
+    await logger.log({ event: 'refresh.crashed' });
     return 0;
   }
 

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -19,6 +19,11 @@ import {
 } from '../cache/store';
 import type { Cache } from '../cache/store';
 import type { ExtraUsage, UsageBucket, UsageResponse } from '../oauth/types';
+import {
+  createDiagnosticLogger,
+  defaultDiagnosticLogPath,
+  type DiagnosticLogger,
+} from '../diagnostics/logger';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -57,6 +62,7 @@ export type SpawnFn = (command: string, args: string[], opts: SpawnOptions) => v
 export interface RenderEnterpriseDeps {
   cachePath?: string;
   bundlePath?: string;
+  logger?: DiagnosticLogger;
   /** Override the spawn call for testing. Receives (command, args, opts). */
   spawnRefresh?: SpawnFn;
   now?: () => number;
@@ -317,6 +323,7 @@ export async function runRenderEnterprise(
   const cachePath = deps.cachePath ?? defaultCachePath();
   const bundlePath = deps.bundlePath ?? __filename;
   const now = deps.now ?? (() => Date.now());
+  const logger = deps.logger ?? createDiagnosticLogger(defaultDiagnosticLogPath(cachePath), { now });
   const spawnFn = deps.spawnRefresh ?? defaultSpawnFn();
 
   // Step 1: Read stdin.
@@ -355,6 +362,27 @@ export async function runRenderEnterprise(
   const inCooldown = cache !== null && cache.rateLimitedUntilMs > nowMs;
 
   const shouldFire = (cacheIsMissing || isStale) && !authFatal && !inFlight && !inCooldown;
+
+  if (cacheIsMissing || isStale) {
+    const reason = cacheIsMissing
+      ? 'cache-missing'
+      : authFatal
+        ? 'auth-fatal'
+        : inFlight
+          ? 'in-flight'
+          : inCooldown
+            ? 'rate-limit-cooldown'
+            : 'stale-cache';
+    void logger.log({
+      event: 'render.refresh_decision',
+      action: shouldFire ? 'spawn' : 'skip',
+      reason,
+      usageAgeMs: Number.isFinite(staleAge) ? staleAge : null,
+      cooldownRemainingMs: inCooldown && cache !== null
+        ? cache.rateLimitedUntilMs - nowMs
+        : 0,
+    });
+  }
 
   if (shouldFire) {
     const minimalEnv = buildMinimalEnv();

--- a/src/subcommands/uninstall.ts
+++ b/src/subcommands/uninstall.ts
@@ -21,6 +21,11 @@ import {
   writeSettings,
   defaultSettingsPath,
 } from '../settings/mutator';
+import {
+  defaultDiagnosticLogDisabledPath,
+  defaultDiagnosticLogPath,
+  withDiagnosticLogLock,
+} from '../diagnostics/logger';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -60,15 +65,13 @@ function tryUnlink(filePath: string): void {
   }
 }
 
-function tryRmdir(dirPath: string): void {
+function tryRmdir(dirPath: string): boolean {
   try {
     fs.rmdirSync(dirPath);
+    return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT' || code === 'ENOTEMPTY') {
-      // ENOENT → already gone; ENOTEMPTY → user has other files, leave it
-      return;
-    }
+    if (code === 'ENOENT' || code === 'ENOTEMPTY') return false;
     throw err;
   }
 }
@@ -80,6 +83,9 @@ function tryRmdir(dirPath: string): void {
 export async function runUninstall(_args: string[], deps: UninstallDeps = {}): Promise<number> {
   const installDir = getInstallDir(deps.homedirOverride);
   const settingsFilePath = deps.settingsPath ?? defaultSettingsPath();
+  const logPath = defaultDiagnosticLogPath(path.join(installDir, 'cache.json'));
+  const disabledLogPath = defaultDiagnosticLogDisabledPath(logPath);
+  let removedInstallDir = false;
 
   // 1. Remove cc-statusline.js
   const rendererPath = path.join(installDir, 'cc-statusline.js');
@@ -89,12 +95,25 @@ export async function runUninstall(_args: string[], deps: UninstallDeps = {}): P
   const cachePath = path.join(installDir, 'cache.json');
   tryUnlink(cachePath);
 
-  // 3. Remove diagnostic logs
-  tryUnlink(path.join(installDir, 'debug.log'));
-  tryUnlink(path.join(installDir, 'debug.log.1'));
+  // 3. Disable diagnostics and remove diagnostic logs.
+  await withDiagnosticLogLock(logPath, async () => {
+    tryUnlink(logPath);
+    tryUnlink(`${logPath}.1`);
 
-  // 4. Remove installDir if empty (leave if user added other files)
-  tryRmdir(installDir);
+    // Remove installDir while lock is still held to prevent recreation races.
+    removedInstallDir = tryRmdir(installDir);
+    if (!removedInstallDir) {
+      try {
+        fs.writeFileSync(disabledLogPath, 'disabled by uninstall', { mode: 0o600 });
+      } catch {
+        // Disabled marker is advisory; best-effort write keeps uninstall idempotent.
+      }
+    }
+  });
+
+  // If uninstall could not remove installDir (usually ENOTEMPTY), we keep the
+  // disable marker so future writers skip diagnostics replay.
+  // If uninstall removed installDir, the disable marker is removed as part of dir removal.
 
   // 5. Clear statusLine from settings.json (if settings file exists)
   const settings = readSettings(settingsFilePath);

--- a/src/subcommands/uninstall.ts
+++ b/src/subcommands/uninstall.ts
@@ -4,6 +4,7 @@
  * Removes:
  *   - <installDir>/cc-statusline.js
  *   - <installDir>/cache.json
+ *   - <installDir>/debug.log and its rotated backup
  *   - <installDir>/ (only if empty after above removals)
  *
  * Clears `statusLine` from ~/.claude/settings.json.
@@ -88,10 +89,14 @@ export async function runUninstall(_args: string[], deps: UninstallDeps = {}): P
   const cachePath = path.join(installDir, 'cache.json');
   tryUnlink(cachePath);
 
-  // 3. Remove installDir if empty (leave if user added other files)
+  // 3. Remove diagnostic logs
+  tryUnlink(path.join(installDir, 'debug.log'));
+  tryUnlink(path.join(installDir, 'debug.log.1'));
+
+  // 4. Remove installDir if empty (leave if user added other files)
   tryRmdir(installDir);
 
-  // 4. Clear statusLine from settings.json (if settings file exists)
+  // 5. Clear statusLine from settings.json (if settings file exists)
   const settings = readSettings(settingsFilePath);
   // readSettings returns {} if file does not exist — check if statusLine was there
   if ('statusLine' in settings) {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   createDiagnosticLogger,
+  defaultDiagnosticLogDisabledPath,
   MAX_DIAGNOSTIC_LOG_BYTES,
   readDiagnosticLog,
 } from '../src/diagnostics/logger';
@@ -59,5 +60,30 @@ describe('diagnostic logger', () => {
 
     const output = await readDiagnosticLog(logPath);
     expect(output).toBe('{"event":"old"}\n{"event":"new"}\n');
+  });
+
+  it('serializes concurrent writes so rotation does not lose events', async () => {
+    const tmpDir = makeTmpDir();
+    const logPath = path.join(tmpDir, 'debug.log');
+    fs.writeFileSync(logPath, 'x'.repeat(MAX_DIAGNOSTIC_LOG_BYTES), { mode: 0o600 });
+
+    await Promise.all([
+      createDiagnosticLogger(logPath).log({ event: 'refresh.started' }),
+      createDiagnosticLogger(logPath).log({ event: 'refresh.completed' }),
+    ]);
+
+    const output = await readDiagnosticLog(logPath);
+    expect(output).toContain('"event":"refresh.started"');
+    expect(output).toContain('"event":"refresh.completed"');
+  });
+
+  it('does not recreate logs while diagnostics are disabled', async () => {
+    const tmpDir = makeTmpDir();
+    const logPath = path.join(tmpDir, 'debug.log');
+    fs.writeFileSync(defaultDiagnosticLogDisabledPath(logPath), 'disabled\n', { mode: 0o600 });
+
+    await createDiagnosticLogger(logPath).log({ event: 'refresh.skipped' });
+
+    expect(fs.existsSync(logPath)).toBe(false);
   });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -30,7 +30,9 @@ describe('diagnostic logger', () => {
       reason: 'stale-cache',
     });
     expect(typeof event['pid']).toBe('number');
-    expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
+    }
   });
 
   it('rotates the active log when it exceeds the configured bound', async () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  createDiagnosticLogger,
+  MAX_DIAGNOSTIC_LOG_BYTES,
+  readDiagnosticLog,
+} from '../src/diagnostics/logger';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-diagnostics-test-'));
+}
+
+describe('diagnostic logger', () => {
+  it('writes structured events with restrictive file permissions', async () => {
+    const tmpDir = makeTmpDir();
+    const logPath = path.join(tmpDir, 'debug.log');
+
+    await createDiagnosticLogger(logPath, { now: () => 1_700_000_000_000 }).log({
+      event: 'refresh.started',
+      reason: 'stale-cache',
+    });
+
+    const line = fs.readFileSync(logPath, 'utf8').trim();
+    const event = JSON.parse(line) as Record<string, unknown>;
+    expect(event).toMatchObject({
+      timestamp: '2023-11-14T22:13:20.000Z',
+      event: 'refresh.started',
+      reason: 'stale-cache',
+    });
+    expect(typeof event['pid']).toBe('number');
+    expect(fs.statSync(logPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('rotates the active log when it exceeds the configured bound', async () => {
+    const tmpDir = makeTmpDir();
+    const logPath = path.join(tmpDir, 'debug.log');
+    fs.writeFileSync(logPath, 'x'.repeat(MAX_DIAGNOSTIC_LOG_BYTES), { mode: 0o600 });
+
+    await createDiagnosticLogger(logPath, { now: () => 1_700_000_000_000 }).log({
+      event: 'refresh.completed',
+      result: 'success',
+    });
+
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+    expect(fs.statSync(`${logPath}.1`).size).toBe(MAX_DIAGNOSTIC_LOG_BYTES);
+    expect(fs.readFileSync(logPath, 'utf8')).toContain('refresh.completed');
+    expect(fs.statSync(logPath).size).toBeLessThanOrEqual(MAX_DIAGNOSTIC_LOG_BYTES);
+  });
+
+  it('reads retained history in chronological file order', async () => {
+    const tmpDir = makeTmpDir();
+    const logPath = path.join(tmpDir, 'debug.log');
+    fs.writeFileSync(`${logPath}.1`, '{"event":"old"}\n', { mode: 0o600 });
+    fs.writeFileSync(logPath, '{"event":"new"}\n', { mode: 0o600 });
+
+    const output = await readDiagnosticLog(logPath);
+    expect(output).toBe('{"event":"old"}\n{"event":"new"}\n');
+  });
+});

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -85,6 +85,8 @@ describe('runDoctor', () => {
     expect(output).toContain('authState:     ok');
     expect(output).toContain('last usage:    30s ago');
     expect(output).toContain('rate limit:    not rate-limited');
+    expect(output).toContain('credential use: local cache (cache.json)');
+    expect(output).toContain('credential origin: not recorded');
   });
 
   it('cooldown active: shows cooldown remaining', async () => {
@@ -124,5 +126,37 @@ describe('runDoctor', () => {
     await runDoctor([], { cachePath: cachePathOf(tmpDir), now: () => now });
     const output = captured.join('');
     expect(output).toContain('header present');
+  });
+
+  it('prints retained diagnostic events with --logs without exposing credentials', async () => {
+    const now = Date.now();
+    const cache = makeCache();
+    const cachePath = cachePathOf(tmpDir);
+    const logPath = path.join(tmpDir, 'debug.log');
+    await writeCache(cache, cachePath);
+    fs.writeFileSync(
+      logPath,
+      JSON.stringify({
+        timestamp: '2026-07-22T10:00:00.000Z',
+        pid: 123,
+        event: 'usage.response',
+        status: 429,
+        retryAfterSeconds: 120,
+      }) + '\n',
+      { mode: 0o600 },
+    );
+
+    await runDoctor(['--logs'], {
+      cachePath,
+      logPath,
+      now: () => now,
+    });
+
+    const output = captured.join('');
+    expect(output).toContain('diagnostics:');
+    expect(output).toContain('usage.response');
+    expect(output).toContain('"status":429');
+    expect(output).not.toContain('sk-ant-secret-do-not-leak');
+    expect(output).not.toContain('rt-secret-do-not-leak');
   });
 });

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { runRefresh } from '../src/subcommands/refresh';
 import { readCache, writeCache, type Cache } from '../src/cache/store';
 import type { UsageResponse } from '../src/oauth/types';
+import { readDiagnosticLog } from '../src/diagnostics/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -576,6 +577,14 @@ describe('runRefresh', () => {
     expect(result!.lastErrorMessage).toContain('header present');
     expect(result!.lastErrorMessage).toContain('x-should-retry: false');
     expect(result!.rateLimitedUntilMs).toBe(frozenNow + 120_000);
+
+    const log = await readDiagnosticLog(path.join(tmpDir, 'debug.log'));
+    expect(log).toContain('"event":"http.result"');
+    expect(log).toContain('"endpoint":"usage"');
+    expect(log).toContain('"status":429');
+    expect(log).toContain('"retryAfterSeconds":120');
+    expect(log).not.toContain('at-rl');
+    expect(log).not.toContain('rt-rl');
   });
 
   it('12b. rate-limited with header absent: lastErrorMessage notes default applied', async () => {

--- a/tests/render-enterprise.test.ts
+++ b/tests/render-enterprise.test.ts
@@ -131,6 +131,7 @@ import {
 } from '../src/subcommands/render-enterprise';
 import { STALE_MARKER, MISSING } from '../src/statusline/format';
 import * as storeModule from '../src/cache/store';
+import type { DiagnosticLogger } from '../src/diagnostics/logger';
 
 // ---------------------------------------------------------------------------
 // Global setup / teardown
@@ -152,6 +153,7 @@ async function runWithCache(
   stdinContent: string,
   extra: {
     now?: () => number;
+    logger?: DiagnosticLogger;
     spawnCalls?: Array<{ command: string; args: string[]; opts: SpawnOptions }>;
   } = {},
 ): Promise<{ output: string; exitCode: number; spawnCalls: Array<{ command: string; args: string[]; opts: SpawnOptions }> }> {
@@ -167,6 +169,7 @@ async function runWithCache(
           cachePath: '/mocked',
           bundlePath: '/bundle.js',
           now: extra.now ?? (() => Date.now()),
+          logger: extra.logger ?? { log: async () => {} },
           spawnRefresh: (command, args, opts) => {
             calls.push({ command, args, opts });
             if (extra.spawnCalls) extra.spawnCalls.push({ command, args, opts });
@@ -649,6 +652,37 @@ describe('Scenario 10: refresh already in-flight — no new spawn', () => {
   });
 });
 
+describe('diagnostic refresh decisions', () => {
+  it('records a stale-cache spawn decision without changing rendered output', async () => {
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: NOW - 5 * 60 * 1000,
+    });
+    const events: Array<Record<string, unknown>> = [];
+
+    const { output, spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      {
+        now: () => NOW,
+        logger: {
+          log: async (details) => {
+            events.push(details);
+          },
+        },
+      },
+    );
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(output).toContain(STALE_MARKER);
+    expect(events).toContainEqual(expect.objectContaining({
+      event: 'render.refresh_decision',
+      action: 'spawn',
+      reason: 'stale-cache',
+    }));
+  });
+});
+
 // ============================================================================
 // Scenario 11 (R15): Synchronous bound — returns within 30ms even when spawn needed
 // ============================================================================
@@ -671,6 +705,7 @@ describe('Scenario 11 (R15): synchronous performance bound', () => {
           cachePath: '/mocked',
           bundlePath: '/bundle.js',
           now: () => NOW,
+          logger: { log: async () => {} },
           // Simulate async work in spawn — but runRenderEnterprise must not await it.
           spawnRefresh: (_command, _args, _opts) => {
             spawnCalled = true;
@@ -926,6 +961,7 @@ describe('Scenario 19: spawn shape differs by platform', () => {
             cachePath: '/mocked',
             bundlePath: '/my/bundle.js',
             now: () => NOW,
+            logger: { log: async () => {} },
             spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
           },
         ),
@@ -962,6 +998,7 @@ describe('Scenario 19: spawn shape differs by platform', () => {
             cachePath: '/mocked',
             bundlePath: 'C:\\bundle.js',
             now: () => NOW,
+            logger: { log: async () => {} },
             spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
           },
         ),
@@ -1003,6 +1040,7 @@ describe('Scenario 20: minimal env — no secrets passed to spawn', () => {
             cachePath: '/mocked',
             bundlePath: '/bundle.js',
             now: () => NOW,
+            logger: { log: async () => {} },
             spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
           },
         ),
@@ -1035,6 +1073,7 @@ describe('Scenario 20: minimal env — no secrets passed to spawn', () => {
             cachePath: '/mocked',
             bundlePath: '/bundle.js',
             now: () => NOW,
+            logger: { log: async () => {} },
             spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
           },
         ),

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -13,6 +13,7 @@ import * as path from 'node:path';
 import { runUninstall, type UninstallDeps } from '../src/subcommands/uninstall';
 import { readSettings, writeSettings } from '../src/settings/mutator';
 import { writeCache, type Cache } from '../src/cache/store';
+import { createDiagnosticLogger, defaultDiagnosticLogDisabledPath } from '../src/diagnostics/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -309,5 +310,30 @@ describe('T7: re-running uninstall is idempotent', () => {
     // Second run — everything is already gone
     const code2 = await runUninstall([], deps);
     expect(code2).toBe(0);
+  });
+});
+
+describe('T8: uninstall disables active diagnostics replay', () => {
+  it('keeps a diagnostics disable marker so no new debug.log can be recreated after uninstall', async () => {
+    const tmpDir = makeTmpDir();
+
+    writeRenderer(tmpDir);
+    const customFile = path.join(getInstallDir(tmpDir), 'my-custom-config.json');
+    fs.writeFileSync(customFile, '{"custom": true}\n', 'utf8');
+    writeDiagnosticLogs(tmpDir);
+
+    const deps = baseDeps(tmpDir);
+    const code = await runUninstall([], deps);
+    expect(code).toBe(0);
+
+    const diagnosticPath = getDiagnosticLogPath(tmpDir);
+    const disabledPath = defaultDiagnosticLogDisabledPath(diagnosticPath);
+    expect(fs.existsSync(disabledPath)).toBe(true);
+    expect(fs.existsSync(diagnosticPath)).toBe(false);
+    expect(fs.existsSync(`${diagnosticPath}.1`)).toBe(false);
+    expect(fs.existsSync(getInstallDir(tmpDir))).toBe(true);
+
+    await createDiagnosticLogger(diagnosticPath).log({ event: 'refresh.skipped' });
+    expect(fs.existsSync(diagnosticPath)).toBe(false);
   });
 });

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -63,6 +63,10 @@ function getCachePath(dir: string): string {
   return path.join(getInstallDir(dir), 'cache.json');
 }
 
+function getDiagnosticLogPath(dir: string): string {
+  return path.join(getInstallDir(dir), 'debug.log');
+}
+
 function writeRenderer(dir: string): void {
   const p = getRendererPath(dir);
   fs.mkdirSync(path.dirname(p), { recursive: true });
@@ -88,6 +92,11 @@ async function writeTestCache(dir: string): Promise<void> {
     rateLimitedUntilMs: 0,
   };
   await writeCache(cache, getCachePath(dir));
+}
+
+function writeDiagnosticLogs(dir: string): void {
+  fs.writeFileSync(getDiagnosticLogPath(dir), '{"event":"test"}\n', { mode: 0o600 });
+  fs.writeFileSync(`${getDiagnosticLogPath(dir)}.1`, '{"event":"old"}\n', { mode: 0o600 });
 }
 
 const COMMAND = '/home/user/.claude/cc-statusline/cc-statusline.js render-promax';
@@ -119,6 +128,7 @@ describe('T1: AE6 clean install state', () => {
 
     writeRenderer(tmpDir);
     await writeTestCache(tmpDir);
+    writeDiagnosticLogs(tmpDir);
 
     // Write settings with statusLine and sibling keys
     writeJson(settingsPath(tmpDir), {
@@ -137,6 +147,10 @@ describe('T1: AE6 clean install state', () => {
 
     // Cache removed
     expect(fs.existsSync(getCachePath(tmpDir))).toBe(false);
+
+    // Diagnostic logs removed
+    expect(fs.existsSync(getDiagnosticLogPath(tmpDir))).toBe(false);
+    expect(fs.existsSync(`${getDiagnosticLogPath(tmpDir)}.1`)).toBe(false);
 
     // Install dir removed (was empty after above)
     expect(fs.existsSync(getInstallDir(tmpDir))).toBe(false);


### PR DESCRIPTION
## What

Intermittent rate-limit reports were difficult to distinguish from repeated refreshes, token refreshes, or another client using the same credential. This adds bounded, token-free Enterprise refresh diagnostics, exposes them through `doctor --logs`, documents credential discovery and storage, and makes `doctor` state that API calls use the local cache while the original credential origin is not recorded.

This does not observe other applications using the same account or persist historical credential provenance; those remain follow-up work requiring server-side evidence and a cache/credential design discussion.

Related: rate-limit investigation feedback

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` — 322 tests passing

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] No changes in `credentials/`, `oauth/`, or `cache/` were made
