### PR TITLE
fix: delegate enterprise auth recovery to Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # cc-statusline
 
-Usage-aware Claude Code statusline. The CLI reads OAuth tokens from the macOS keychain or `~/.claude/.credentials.json`, caches them at `~/.claude/cc-statusline/cache.json`, and renders usage in the Claude Code prompt area.
+Usage-aware Claude Code statusline. The CLI discovers OAuth credentials from Claude Code or an explicit file, stores an access-token-only usage cache at `~/.claude/cc-statusline/cache.json`, and renders usage in the Claude Code prompt area. Claude Code owns credential renewal.
 
 ## Stack
 
@@ -23,25 +23,25 @@ Run before declaring a change done:
 
 - Every `child_process.spawn` call passes `shell: false` and an argv array. Never `shell: true`, never a single string command.
 - Cache files are written with mode `0600`. The install dir `~/.claude/cc-statusline/` is created with mode `0700`.
-- Any error string that may have originated from token-handling or HTTP response paths is passed through `sanitizeErrorMessage(message, credentials)` before being persisted (cache, log, stderr).
-- Any flag or input accepting a file path is validated with `fs.realpath` and rejected if it resolves outside the user's homedir or points to a non-regular file. Pattern: `validateCredentialsPath` in `src/subcommands/init.ts`.
+- Any error string that may have originated from token-handling or HTTP response paths is passed through `sanitizeErrorMessage(message, credentials, candidateCredentials?)` before being persisted (cache, log, stderr). Candidate source credentials must be included when they may differ from the cached access token.
+- Any flag or input accepting a file path is validated with `fs.realpath` and rejected if it resolves outside the user's homedir or points to a non-regular file. Pattern: `canonicalizeFileCredentialSource` in `src/credentials/source.ts`.
 
 Changes inside `src/credentials/`, `src/oauth/`, or `src/cache/` require a design-discussed issue before any code is written. See `CONTRIBUTING.md`.
 
 ## Test conventions
 
 - Tests must not touch real `~/.claude/`, the macOS keychain, or the network. Use `os.tmpdir()` + `mkdtempSync` for filesystem isolation.
-- Subcommand entrypoints accept a `Deps` interface (e.g. `InitDeps`) exposing override hooks: `homedirOverride`, `platformOverride`, `spawnRefresh`, `discoverImpl`, `pasteReader`, etc. Tests inject mocks via these; production calls omit them and get the defaults.
+- Subcommand entrypoints accept a `Deps` interface (e.g. `InitDeps`) exposing override hooks at system boundaries: `homedirOverride`, `platformOverride`, `spawnClaude`, `spawnRefresh`, `fetchImpl`, `discoverImpl`, and `loadCredentialSourceImpl`. Tests inject mocks via these; production calls omit them and get the defaults.
 - Mock only at system boundaries — filesystem, network, `child_process`, time. Never mock internal modules.
 - Fixtures live in `tests/fixtures/`.
 
 ## OAuth result handling
 
-`refresh()` and `fetchUsage()` in `src/oauth/client.ts` return discriminated unions with a `kind` field: `success | auth-fatal | cloudflare-blocked | rate-limited | transient`. Every caller must handle every variant explicitly. Do not collapse to `try/catch` over the call.
+`fetchUsage()` in `src/oauth/client.ts` returns a discriminated union with a `kind` field: `success | auth-fatal | cloudflare-blocked | rate-limited | transient`. Every caller must handle every variant explicitly. Do not collapse it to `try/catch`.
 
 ## Cache schema
 
-`Cache` in `src/cache/store.ts` carries a `schemaVersion` literal. Any shape change must bump the version, and `readCache` must return `null` for older versions so `init` rebuilds cleanly.
+`Cache` in `src/cache/store.ts` carries a `schemaVersion` literal. Schema v4 persists only `accessToken` and `expiresAt` under `credentials`, plus a `credentialSource` of `claude-code` or an authoritative explicit file path. It never persists a refresh token. Background refresh rereads the recorded source so it can adopt access-token renewal performed by Claude Code or the explicit source owner. Any shape change must bump the version, and `readCache` must return `null` for older versions so `init` rebuilds cleanly.
 
 ## Bundle constraints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ npm run typecheck  # tsc --noEmit
 
 ```
 src/
-  cache/          token + usage cache (read/write, 0600 mode)
-  credentials/    platform-aware OAuth credential discovery
-  oauth/          token refresh and usage API client
+  cache/          access-token + usage cache (schema v4, 0600 mode)
+  credentials/    OAuth credential discovery and source rereading
+  oauth/          usage API client
   settings/       ~/.claude/settings.json mutator
   statusline/     output formatter + stdin reader for Claude Code
   subcommands/    init, uninstall, refresh, render-promax, render-enterprise

--- a/README.md
+++ b/README.md
@@ -12,10 +12,37 @@ Use `--plan pro`, `--plan max`, or `--plan enterprise`. The installer writes the
 
 Claude Code only runs custom statusline commands after the current workspace is trusted. If you see `statusline skipped · restart to fix`, accept the workspace trust prompt for the project and restart Claude Code.
 
+### Enterprise authentication
+
+Enterprise setup validates Claude Code's current credential against the usage API. If the credential is missing or rejected during an interactive install, cc-statusline checks `claude auth status` to explain what it found, then starts the official:
+
+```bash
+claude auth login
+```
+
+The status command is explanatory only. A successful usage API response is authoritative, and setup does not persist credentials until that validation succeeds.
+
+For terminals or automation where prompts are unavailable, authenticate first and then run the installer explicitly:
+
+```bash
+claude auth login
+npx @nkootstra/cc-statusline --plan enterprise --non-interactive
+```
+
+`--non-interactive` never starts login or prompts. It requires `--plan`; add `--force` if an existing statusline command must be replaced.
+
+Enterprise users upgrading from a cache version before schema v4 must run Enterprise init once:
+
+```bash
+npx @nkootstra/cc-statusline --plan enterprise
+```
+
+Older caches are intentionally ignored. Until init creates a v4 cache, the statusline shows `usage — · run init` and does not launch background refreshes.
+
 ## What you'll see
 
 - **Pro / Max**: model name plus colorized 5-hour and 7-day rate-limit utilization.
-- **Enterprise**: model name plus cached monthly credits used / credits limit when monthly credits are enabled. Falls back to colorized 5-hour and 7-day rate-limit utilization. The credits figure comes from a local OAuth usage cache that is refreshed in the background every 60 seconds; a ` ~` marker appears when the cached value is older than that. The stale window is configurable with `CC_STATUSLINE_ENTERPRISE_STALE_MS` and clamped to 10–300 seconds. When Claude Code reports a non-zero current-session cost, it appears separately as `session $...`; this is Claude Code's client-side estimate and may differ from actual billing.
+- **Enterprise**: model name plus cached monthly credits used / credits limit when monthly credits are enabled. Falls back to colorized 5-hour and 7-day rate-limit utilization. The credits figure comes from a local OAuth usage cache that is refreshed in the background every 60 seconds; a ` ~` marker appears when the cached value is older than that. The stale window is configurable with `CC_STATUSLINE_ENTERPRISE_STALE_MS` and clamped to 10–300 seconds. When Claude Code reports a non-zero current-session cost, it appears separately as `session $...`; this is Claude Code's client-side estimate and may differ from actual billing. If authentication cannot be repaired from the recorded source, the statusline shows `run init to repair auth`.
 
 The enterprise renderer also enforces a cooldown after API `429` responses. If the server asks a retry delay, cc-statusline will wait before refreshing usage again, and this cooldown can grow across repeated 429s (bounded to five minutes) to avoid repeated rate-limit churn.
 
@@ -47,11 +74,11 @@ npx @nkootstra/cc-statusline --version
 npx @nkootstra/cc-statusline uninstall
 ```
 
-Removes the statusline entry from `~/.claude/settings.json` and deletes the installed renderer. The OAuth refresh token is **not** revoked — it expires naturally.
+Removes the statusline entry from `~/.claude/settings.json`, the installed renderer, and cc-statusline's cache and diagnostics. It does not revoke or modify the Claude Code login or an explicit credential source; those remain owned by their source.
 
 ## Security note
 
-cc-statusline reads Claude Code's stored OAuth credential (macOS keychain or `~/.claude/.credentials.json`) once at install and copies it to `~/.claude/cc-statusline/cache.json` (mode `0600`). This file is rewritten as the token rotates. Compromise of your home directory exposes the same tokens Claude Code already exposes there.
+The v4 cache at `~/.claude/cc-statusline/cache.json` is mode `0600` and contains an access token, its expiry, usage data, and credential-source provenance. It never contains a refresh token. Claude Code owns credential renewal: cc-statusline never sends a refresh token to an OAuth endpoint and never stores one. When cc-statusline reads a Claude Code credential envelope, any refresh token in that source exists in memory only during source loading and error sanitization.
 
 ## Credentials and investigation
 
@@ -61,11 +88,13 @@ During `init`, automatic credential discovery uses this order:
 2. `~/.claude/.credentials.json`
 3. `~/.claude/credentials.json`
 
-`--credentials-path=<path>` overrides automatic discovery. The discovered OAuth envelope contains an `accessToken`, a `refreshToken`, and an expiry time. cc-statusline copies those values into its local cache and uses that cache for subsequent requests. The cache is located at `~/.claude/cc-statusline/cache.json`, or under `$CLAUDE_CONFIG_DIR/cc-statusline/cache.json` when `CLAUDE_CONFIG_DIR` is set.
+Automatic discovery is recorded as the `Claude Code` credential source. `--credentials-path=<path>` instead records an `explicit file` source. The explicit path is authoritative: background refresh rereads that file and does not fall back to Keychain or another Claude Code credential location. The path is resolved with `realpath`, must remain a regular file inside the user's home directory, and is never printed by `doctor`.
 
-The `accessToken` is sent as a Bearer token to the usage endpoint. The `refreshToken` is sent to the OAuth token endpoint only when the access token is close to expiry; rotated credentials are then written back to the local cache. Reinstalling with `--force` can therefore replace the local cache with credentials rediscovered from the original source.
+Only the `accessToken` is copied into the cache and sent as a Bearer token to the Anthropic usage endpoint. The cache is located at `~/.claude/cc-statusline/cache.json`, or under `$CLAUDE_CONFIG_DIR/cc-statusline/cache.json` when `CLAUDE_CONFIG_DIR` is set.
 
-`cc-statusline doctor` reports that API calls use the local cache. Current cache versions do not retain whether the cache was originally populated from Keychain, a credentials file, or `--credentials-path`, so `doctor` reports that origin as “not recorded.” The statusline’s diagnostics also cannot observe Claude Code or another application using the same account or OAuth credential; server-side/account-level evidence would be required for that.
+Background refresh rereads the recorded source when the cached access token is near expiry, after a usage `401`, or while recovering from fatal authentication. With the `Claude Code` source, this lets cc-statusline pick up an access token renewed by Claude Code. cc-statusline itself does not rotate credentials. If source rereading cannot repair fatal authentication, run init as instructed by the statusline.
+
+`cc-statusline doctor` reports `credential source: Claude Code` or `credential source: explicit file`, never the source path or token values. The statusline’s diagnostics cannot observe Claude Code or another application using the same account or OAuth credential; server-side/account-level evidence would be required for that.
 
 ## Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,24 @@ Claude Code only runs custom statusline commands after the current workspace is 
 
 ### Enterprise authentication
 
-Enterprise setup validates Claude Code's current credential against the usage API. If the credential is missing or rejected during an interactive install, cc-statusline checks `claude auth status` to explain what it found, then starts the official:
+Enterprise setup validates Claude Code's current credential against the usage API. If the credential is missing, expired, or rejected during an interactive install, cc-statusline checks `claude auth status` to explain what it found, then starts the official:
 
 ```bash
 claude auth login
 ```
 
 The status command is explanatory only. A successful usage API response is authoritative, and setup does not persist credentials until that validation succeeds.
+
+| Enterprise init condition | Behavior |
+|---|---|
+| Valid, unexpired v4 cache with no `--force` or `--credentials-path` | Reuses the cache without credential discovery, network access, or login. |
+| Missing, expired, or usage-API-rejected Claude Code credential in an interactive terminal | Checks status, starts one login, rediscovers the credential, and validates it before installation. |
+| Authentication required with `--non-interactive` or without a TTY | Starts no Claude command and prints the manual login and install commands. |
+| `--credentials-path=<path>` | Validates only that authoritative file. It never starts Claude login or falls back to automatic discovery. |
+| Cloudflare block, rate limit, or transient network failure | Reports a retryable network failure without starting an unnecessary login. |
+| Cancelled or failed login, missing post-login credentials, or failed post-login validation | Exits without activating a replacement and preserves any existing cache, installed bundle, and statusline setting. |
+
+`--plan enterprise` selects the plan without disabling interactive authentication. `--force` bypasses a valid-looking cache and revalidates the current credential; it starts login only when that credential is missing, expired, or rejected.
 
 For terminals or automation where prompts are unavailable, authenticate first and then run the installer explicitly:
 
@@ -29,7 +40,7 @@ claude auth login
 npx @nkootstra/cc-statusline --plan enterprise --non-interactive
 ```
 
-`--non-interactive` never starts login or prompts. It requires `--plan`; add `--force` if an existing statusline command must be replaced.
+`--non-interactive` never starts login or prompts. It requires `--plan`; add `--force` when the cached credential must be revalidated or an existing statusline command must be replaced.
 
 Enterprise users upgrading from a cache version before schema v4 must run Enterprise init once:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,20 +27,25 @@ I aim to acknowledge reports within **7 days**. Resolution timeline depends on s
 The following are in scope:
 
 - Credential or token exposure beyond the documented home-directory baseline (see [Out of scope](#out-of-scope))
-- Token values appearing in error messages, logs, or cache files
+- Access or refresh token values appearing in errors, logs, diagnostic output, or subprocess arguments
+- A refresh token being persisted in the cc-statusline cache or transmitted by cc-statusline
 - Path traversal via `--credentials-path` or any other flag accepting a file path
 - Cache or install directory created with permissions more permissive than `0600` / `0700`
 - Shell injection through any subprocess invocation
+
+The v4 cache intentionally contains the current access token so background usage requests can run without blocking the statusline. It also contains the access-token expiry, usage data, and credential-source provenance. It must never contain a refresh token.
 
 ## Implemented defences
 
 These mitigations are already in place. Reports for bypasses are in scope; reports that assume these are absent are not:
 
 - All subprocess spawns use `shell: false` — no shell injection via argument values
-- Error messages are sanitised before being written to cache: access and refresh token values are replaced with `<redacted>`
-- `--credentials-path` is validated via `realpath` and rejected if it resolves outside the user's home directory or points to a non-regular file
+- Error messages from credential and HTTP paths are sanitised before being persisted or printed; candidate access and refresh token values are replaced with `<redacted>`
+- `--credentials-path` and stored explicit-file sources are validated via `realpath` and rejected if they resolve outside the user's home directory or point to a non-regular file
 - The cache file is written with mode `0600`; the install directory is created with mode `0700`
+- Claude Code owns token renewal. cc-statusline rereads the selected credential source when necessary and persists only the resulting access token and expiry
+- A refresh token present in a source credential envelope is read in memory only. cc-statusline never writes it to cache, logs it, passes it to a subprocess, or transmits it to an OAuth or usage endpoint
 
 ## Out of scope
 
-If an attacker already has read access to your home directory, they can read the same OAuth tokens that Claude Code stores at `~/.claude/.credentials.json`. The cache at `~/.claude/cc-statusline/cache.json` does not increase that exposure. Home-directory-level compromise is out of scope.
+An attacker with read access to the user's home directory can read cc-statusline's cached access token and may also be able to read Claude Code or explicit-file credentials at their source. Home-directory-level compromise is out of scope. A refresh token found in the cc-statusline cache, diagnostics, output, subprocess arguments, or network traffic remains in scope.

--- a/src/cache/lock.ts
+++ b/src/cache/lock.ts
@@ -1,0 +1,287 @@
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const RETRY_INTERVAL_MS = 10;
+const ACQUIRE_TIMEOUT_MS = 5_000;
+const STALE_LOCK_MS = 2 * 60 * 1000;
+
+interface LockIdentity {
+  pid: number;
+  createdAt: number;
+  token: string;
+}
+
+interface LockTicket extends LockIdentity {
+  ticket: number;
+}
+
+interface LockJson {
+  pid?: unknown;
+  createdAt?: unknown;
+  token?: unknown;
+  ticket?: unknown;
+}
+
+interface LockState {
+  choosing: LockIdentity[];
+  tickets: LockTicket[];
+}
+
+function parseLockJson(raw: string): LockJson | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as LockJson;
+}
+
+function identityFrom(candidate: LockJson): LockIdentity | null {
+  if (
+    typeof candidate.pid !== 'number' ||
+    !Number.isInteger(candidate.pid) ||
+    candidate.pid <= 0 ||
+    typeof candidate.createdAt !== 'number' ||
+    !Number.isFinite(candidate.createdAt) ||
+    typeof candidate.token !== 'string' ||
+    candidate.token.length === 0
+  ) {
+    return null;
+  }
+  return {
+    pid: candidate.pid,
+    createdAt: candidate.createdAt,
+    token: candidate.token,
+  };
+}
+
+function parseIdentity(raw: string): LockIdentity | null {
+  const candidate = parseLockJson(raw);
+  return candidate === null ? null : identityFrom(candidate);
+}
+
+function parseTicket(raw: string): LockTicket | null {
+  const candidate = parseLockJson(raw);
+  const identity = candidate === null ? null : identityFrom(candidate);
+  if (
+    identity === null ||
+    candidate === null ||
+    typeof candidate.ticket !== 'number' ||
+    !Number.isInteger(candidate.ticket) ||
+    candidate.ticket <= 0
+  ) {
+    return null;
+  }
+  return { ...identity, ticket: candidate.ticket };
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function isLive(identity: LockIdentity, now: number): boolean {
+  return (
+    processIsAlive(identity.pid) &&
+    now - identity.createdAt < STALE_LOCK_MS
+  );
+}
+
+async function removeFile(filePath: string): Promise<void> {
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+async function removeEmptyDirectory(dirPath: string): Promise<void> {
+  try {
+    await fs.promises.rmdir(dirPath);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'ENOTEMPTY') throw error;
+  }
+}
+
+async function removeMalformedIfStale(
+  filePath: string,
+  now: number,
+): Promise<void> {
+  try {
+    const stat = await fs.promises.stat(filePath);
+    if (now - stat.mtimeMs >= STALE_LOCK_MS) {
+      await removeFile(filePath);
+    }
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+async function readLockState(lockDir: string, now: number): Promise<LockState> {
+  const entries = await fs.promises.readdir(lockDir, { withFileTypes: true });
+  const state: LockState = { choosing: [], tickets: [] };
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const entryPath = path.join(lockDir, entry.name);
+    if (entry.name.endsWith('.pending')) {
+      await removeMalformedIfStale(entryPath, now);
+      continue;
+    }
+
+    let raw: string;
+    try {
+      raw = await fs.promises.readFile(entryPath, 'utf8');
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+
+    if (entry.name.endsWith('.choosing')) {
+      const identity = parseIdentity(raw);
+      if (identity === null) {
+        await removeMalformedIfStale(entryPath, now);
+      } else if (isLive(identity, now)) {
+        state.choosing.push(identity);
+      } else {
+        await removeFile(entryPath);
+      }
+      continue;
+    }
+
+    if (entry.name.endsWith('.ticket')) {
+      const ticket = parseTicket(raw);
+      if (ticket === null) {
+        await removeMalformedIfStale(entryPath, now);
+      } else if (isLive(ticket, now)) {
+        state.tickets.push(ticket);
+      } else {
+        await removeFile(entryPath);
+      }
+      continue;
+    }
+
+    await removeMalformedIfStale(entryPath, now);
+  }
+
+  state.tickets.sort(
+    (left, right) =>
+      left.ticket - right.ticket ||
+      left.token.localeCompare(right.token),
+  );
+  return state;
+}
+
+async function publish(
+  lockDir: string,
+  name: string,
+  content: LockIdentity | LockTicket,
+): Promise<string> {
+  const destination = path.join(lockDir, name);
+  const pending = path.join(lockDir, `${name}.pending`);
+
+  while (true) {
+    await fs.promises.mkdir(lockDir, { recursive: true, mode: 0o700 });
+    try {
+      await fs.promises.writeFile(pending, JSON.stringify(content), {
+        flag: 'wx',
+        mode: 0o600,
+      });
+      await fs.promises.rename(pending, destination);
+      return destination;
+    } catch (error: unknown) {
+      await removeFile(pending);
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+  }
+}
+
+async function acquire(cachePath: string): Promise<() => Promise<void>> {
+  const lockDir = `${cachePath}.locks`;
+  await fs.promises.mkdir(path.dirname(cachePath), {
+    recursive: true,
+    mode: 0o700,
+  });
+
+  const identity: LockIdentity = {
+    pid: process.pid,
+    createdAt: Date.now(),
+    token: randomUUID(),
+  };
+  const choosingPath = await publish(
+    lockDir,
+    `${identity.token}.choosing`,
+    identity,
+  );
+  let ticketPath: string | undefined;
+
+  try {
+    // Declaring ticket selection first prevents a later contender from
+    // overtaking a writer that has already chosen its place in the queue.
+    const current = await readLockState(lockDir, Date.now());
+    const ticket = current.tickets.reduce(
+      (highest, contender) => Math.max(highest, contender.ticket),
+      0,
+    ) + 1;
+    const contender: LockTicket = { ...identity, ticket };
+    ticketPath = await publish(
+      lockDir,
+      `${identity.token}.ticket`,
+      contender,
+    );
+    await removeFile(choosingPath);
+
+    const startedAt = Date.now();
+    while (true) {
+      const state = await readLockState(lockDir, Date.now());
+      const first = state.tickets[0];
+      if (
+        state.choosing.length === 0 &&
+        first?.token === identity.token
+      ) {
+        const ownedTicketPath = ticketPath;
+        return async () => {
+          await removeFile(ownedTicketPath);
+          await removeEmptyDirectory(lockDir);
+        };
+      }
+
+      if (!state.tickets.some((entry) => entry.token === identity.token)) {
+        throw new Error(`Cache lock contender disappeared: ${ticketPath}`);
+      }
+      if (Date.now() - startedAt >= ACQUIRE_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for cache lock: ${cachePath}`);
+      }
+      await delay(RETRY_INTERVAL_MS);
+    }
+  } catch (error: unknown) {
+    await removeFile(choosingPath);
+    if (ticketPath !== undefined) await removeFile(ticketPath);
+    await removeEmptyDirectory(lockDir);
+    throw error;
+  }
+}
+
+export async function withCacheLock<T>(
+  cachePath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const release = await acquire(cachePath);
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -2,14 +2,21 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import writeFileAtomic from 'write-file-atomic';
-import type { OAuthCredentials, UsageResponse } from '../oauth/types';
+import type { OAuthCredentials } from '../credentials/envelope';
+import type { UsageResponse } from '../oauth/types';
+import { decodeUsageResponse } from '../oauth/usage';
+import type { CredentialSource } from '../credentials/source';
+import { withCacheLock } from './lock';
 
 export type AuthState = 'ok' | 'fatal' | 'cloudflare-blocked';
 
+export type CachedCredentials = Pick<OAuthCredentials, 'accessToken' | 'expiresAt'>;
+
 export interface Cache {
-  schemaVersion: 3;
+  schemaVersion: 4;
   authState: AuthState;
-  credentials: OAuthCredentials;
+  credentials: CachedCredentials;
+  credentialSource: CredentialSource;
   usage: UsageResponse | null;
   lastUsageRefreshAt: number;     // epoch ms; 0 means never
   lastRefreshStartedAt: number;   // epoch ms; 0 means none
@@ -19,6 +26,124 @@ export interface Cache {
   nextRefreshAllowedAt: number;   // epoch ms; 0 means no extra cooldown
   // Consecutive backoff depth for repeated 429s.
   consecutiveRateLimitCount: number; // 0 when no backoff streak
+}
+
+export type CacheUpdate<T> =
+  | { kind: 'write'; cache: Cache; value: T }
+  | { kind: 'skip'; value: T };
+
+interface CachedCredentialsJson {
+  accessToken?: unknown;
+  expiresAt?: unknown;
+}
+
+interface CredentialSourceJson {
+  kind?: unknown;
+  path?: unknown;
+}
+
+interface CacheJson {
+  schemaVersion?: unknown;
+  authState?: unknown;
+  credentials?: unknown;
+  credentialSource?: unknown;
+  usage?: unknown;
+  lastUsageRefreshAt?: unknown;
+  lastRefreshStartedAt?: unknown;
+  lastErrorMessage?: unknown;
+  rateLimitedUntilMs?: unknown;
+  nextRefreshAllowedAt?: unknown;
+  consecutiveRateLimitCount?: unknown;
+}
+
+function parseCachedCredentials(value: unknown): CachedCredentials | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as CachedCredentialsJson;
+  if (
+    typeof candidate.accessToken !== 'string' ||
+    candidate.accessToken.length === 0 ||
+    typeof candidate.expiresAt !== 'number' ||
+    !Number.isFinite(candidate.expiresAt) ||
+    Object.hasOwn(value, 'refreshToken')
+  ) {
+    return null;
+  }
+  return {
+    accessToken: candidate.accessToken,
+    expiresAt: candidate.expiresAt,
+  };
+}
+
+function parseCredentialSource(value: unknown): CredentialSource | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as CredentialSourceJson;
+  if (candidate.kind === 'claude-code') {
+    return { kind: 'claude-code' };
+  }
+  if (
+    candidate.kind !== 'file' ||
+    typeof candidate.path !== 'string' ||
+    candidate.path.length === 0
+  ) {
+    return null;
+  }
+  return { kind: 'file', path: candidate.path };
+}
+
+function parseCache(value: unknown): Cache | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as CacheJson;
+  const credentials = parseCachedCredentials(candidate.credentials);
+  const credentialSource = parseCredentialSource(candidate.credentialSource);
+  const usage = candidate.usage === null
+    ? null
+    : decodeUsageResponse(candidate.usage);
+  const authState = candidate.authState;
+  const lastErrorMessage = candidate.lastErrorMessage;
+
+  if (
+    candidate.schemaVersion !== 4 ||
+    (authState !== 'ok' &&
+      authState !== 'fatal' &&
+      authState !== 'cloudflare-blocked') ||
+    credentials === null ||
+    credentialSource === null ||
+    (usage === null && candidate.usage !== null) ||
+    typeof candidate.lastUsageRefreshAt !== 'number' ||
+    !Number.isFinite(candidate.lastUsageRefreshAt) ||
+    typeof candidate.lastRefreshStartedAt !== 'number' ||
+    !Number.isFinite(candidate.lastRefreshStartedAt) ||
+    (lastErrorMessage !== null && typeof lastErrorMessage !== 'string') ||
+    typeof candidate.rateLimitedUntilMs !== 'number' ||
+    !Number.isFinite(candidate.rateLimitedUntilMs) ||
+    typeof candidate.nextRefreshAllowedAt !== 'number' ||
+    !Number.isFinite(candidate.nextRefreshAllowedAt) ||
+    typeof candidate.consecutiveRateLimitCount !== 'number' ||
+    !Number.isInteger(candidate.consecutiveRateLimitCount) ||
+    candidate.consecutiveRateLimitCount < 0
+  ) {
+    return null;
+  }
+
+  return {
+    schemaVersion: 4,
+    authState,
+    credentials,
+    credentialSource,
+    usage,
+    lastUsageRefreshAt: candidate.lastUsageRefreshAt,
+    lastRefreshStartedAt: candidate.lastRefreshStartedAt,
+    lastErrorMessage,
+    rateLimitedUntilMs: candidate.rateLimitedUntilMs,
+    nextRefreshAllowedAt: candidate.nextRefreshAllowedAt,
+    consecutiveRateLimitCount: candidate.consecutiveRateLimitCount,
+  };
 }
 
 export function defaultCachePath(): string {
@@ -46,74 +171,68 @@ export function readCache(cachePath?: string): Cache | null {
     return null;
   }
 
-  if (typeof parsed !== 'object' || parsed === null) {
-    return null;
-  }
-
-  const obj = parsed as Record<string, unknown>;
-  const version = obj['schemaVersion'];
-
-  if (version === 3) {
-    return obj as unknown as Cache;
-  }
-
-  if (version === 2) {
-    return {
-      ...(obj as Omit<
-        Cache,
-        'schemaVersion' | 'nextRefreshAllowedAt' | 'consecutiveRateLimitCount'
-      >),
-      schemaVersion: 3,
-      nextRefreshAllowedAt: 0,
-      consecutiveRateLimitCount: 0,
-    };
-  }
-
-  // v1/v2 → v3: additive migration to add adaptive backoff fields.
-  // Bumping cleanly per AGENTS.md (every shape change bumps the version) while
-  // preserving the user's tokens + usage across upgrade. Anything older or
-  // unrecognized falls through to null so init can rebuild.
-  if (version === 1) {
-    return {
-      ...(obj as Omit<
-        Cache,
-        'schemaVersion' |
-          'rateLimitedUntilMs' |
-          'nextRefreshAllowedAt' |
-          'consecutiveRateLimitCount'
-      >),
-      schemaVersion: 3,
-      rateLimitedUntilMs: 0,
-      nextRefreshAllowedAt: 0,
-      consecutiveRateLimitCount: 0,
-    };
-  }
-
-  return null;
+  return parseCache(parsed);
 }
 
-export async function writeCache(cache: Cache, cachePath?: string): Promise<void> {
-  const filePath = cachePath ?? defaultCachePath();
+async function writeCacheUnlocked(cache: Cache, filePath: string): Promise<void> {
   const dir = path.dirname(filePath);
   await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-  const content = JSON.stringify(cache, null, 2) + '\n';
+  const persistedCache: Cache = {
+    ...cache,
+    credentials: {
+      accessToken: cache.credentials.accessToken,
+      expiresAt: cache.credentials.expiresAt,
+    },
+  };
+  const content = JSON.stringify(persistedCache, null, 2) + '\n';
   await writeFileAtomic(filePath, content, { mode: 0o600 });
 }
 
+export async function writeCache(
+  cache: Cache,
+  cachePath?: string,
+): Promise<void> {
+  const filePath = cachePath ?? defaultCachePath();
+  await withCacheLock(filePath, () => writeCacheUnlocked(cache, filePath));
+}
+
+export async function updateCache<T>(
+  cachePath: string,
+  updater: (current: Cache | null) => CacheUpdate<T>,
+): Promise<T> {
+  return withCacheLock(cachePath, async () => {
+    const update = updater(readCache(cachePath));
+    if (update.kind === 'write') {
+      await writeCacheUnlocked(update.cache, cachePath);
+    }
+    return update.value;
+  });
+}
+
 export function isRefreshInFlight(cache: Cache, now: number = Date.now()): boolean {
-  return now - cache.lastRefreshStartedAt < 1000;
+  return (
+    cache.lastRefreshStartedAt !== 0 &&
+    now - cache.lastRefreshStartedAt < 45_000
+  );
 }
 
 export function sanitizeErrorMessage(
   message: string,
-  credentials: OAuthCredentials,
+  credentials: CachedCredentials | OAuthCredentials,
+  candidateCredentials?: OAuthCredentials,
 ): string {
   let result = message;
-  if (credentials.accessToken.length > 0) {
-    result = result.split(credentials.accessToken).join('<redacted>');
-  }
-  if (credentials.refreshToken.length > 0) {
-    result = result.split(credentials.refreshToken).join('<redacted>');
+  const candidates = [credentials, candidateCredentials];
+  for (const candidate of candidates) {
+    if (candidate === undefined) continue;
+    if (candidate.accessToken.length > 0) {
+      result = result.split(candidate.accessToken).join('<redacted>');
+    }
+    const refreshToken =
+      'refreshToken' in candidate ? candidate.refreshToken : undefined;
+    if (typeof refreshToken === 'string' && refreshToken.length > 0) {
+      result = result.split(refreshToken).join('<redacted>');
+    }
   }
   return result;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,12 +19,12 @@ const PKG_VERSION: string = ((): string => {
 const HELP = `cc-statusline — usage-aware Claude Code statusline + installer
 
 Usage:
-  cc-statusline [--plan pro|max|enterprise] [--credentials-path=<path>] [--force]
-  cc-statusline init [--plan pro|max|enterprise] [--credentials-path=<path>] [--force]
+  cc-statusline [--plan pro|max|enterprise] [--credentials-path=<path>] [--non-interactive] [--force]
+  cc-statusline init [--plan pro|max|enterprise] [--credentials-path=<path>] [--non-interactive] [--force]
   cc-statusline uninstall
   cc-statusline render-promax       (invoked by Claude Code; reads stdin)
   cc-statusline render-enterprise   (invoked by Claude Code; reads stdin)
-  cc-statusline refresh             (background token + usage refresh)
+  cc-statusline refresh             (background credential + usage refresh)
   cc-statusline doctor [--logs]     (print cache diagnostics; no credentials)
   cc-statusline --version           (print the installed version)
 

--- a/src/credentials/discover.ts
+++ b/src/credentials/discover.ts
@@ -43,6 +43,7 @@ export class CredentialNotFoundError extends Error {
 export interface DiscoverOptions {
   /** Override homedir for testing. */
   homedirOverride?: string;
+  claudeConfigDirOverride?: string;
   /** Override platform for testing. */
   platformOverride?: NodeJS.Platform;
   /**
@@ -147,16 +148,13 @@ function readFromKeychain(
  * Throws `SyntaxError` or `InvalidEnvelopeError` on malformed content
  * (wraps with context naming the file).
  */
-async function readFromFile(
+export async function readCredentialFile(
   filePath: string,
-  readFileFn: typeof nodeReadFile,
+  readFileFn: typeof nodeReadFile = nodeReadFile,
 ): Promise<OAuthCredentials | null> {
   let raw: string;
   try {
-    // The overloaded signature makes TS unhappy with the union; cast to any to
-    // call with explicit 'utf-8' encoding and get a string back.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    raw = await (readFileFn as any)(filePath, 'utf-8') as string;
+    raw = await readFileFn(filePath, 'utf-8');
   } catch (err) {
     const e = err as NodeJS.ErrnoException;
     if (e.code === 'ENOENT') {
@@ -176,10 +174,8 @@ async function readFromFile(
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch (err) {
-    throw new Error(
-      `Credential file ${filePath} contains invalid JSON: ${(err as Error).message}`,
-    );
+  } catch {
+    throw new Error(`Credential file ${filePath} contains invalid JSON`);
   }
 
   // decodeEnvelope throws InvalidEnvelopeError on missing/invalid fields.
@@ -211,6 +207,10 @@ async function readFromFile(
 export async function discover(options?: DiscoverOptions): Promise<OAuthCredentials> {
   const platform = options?.platformOverride ?? process.platform;
   const home = options?.homedirOverride ?? nodeHomedir();
+  const configDir =
+    options?.claudeConfigDirOverride ??
+    process.env['CLAUDE_CONFIG_DIR'] ??
+    join(home, '.claude');
   const spawnFn = options?.spawnOverride ?? nodeSpawn;
   const readFileFn = options?.readFileOverride ?? nodeReadFile;
 
@@ -227,17 +227,17 @@ export async function discover(options?: DiscoverOptions): Promise<OAuthCredenti
   }
 
   // ── Step 2: ~/.claude/.credentials.json ────────────────────────────────
-  const dotCredPath = join(home, '.claude', '.credentials.json');
+  const dotCredPath = join(configDir, '.credentials.json');
   pathsTried.push(dotCredPath);
-  const dotCredResult = await readFromFile(dotCredPath, readFileFn);
+  const dotCredResult = await readCredentialFile(dotCredPath, readFileFn);
   if (dotCredResult !== null) {
     return dotCredResult;
   }
 
   // ── Step 3: ~/.claude/credentials.json ─────────────────────────────────
-  const credPath = join(home, '.claude', 'credentials.json');
+  const credPath = join(configDir, 'credentials.json');
   pathsTried.push(credPath);
-  const credResult = await readFromFile(credPath, readFileFn);
+  const credResult = await readCredentialFile(credPath, readFileFn);
   if (credResult !== null) {
     return credResult;
   }

--- a/src/credentials/source.ts
+++ b/src/credentials/source.ts
@@ -1,0 +1,97 @@
+import { realpath as nodeRealpath, stat as nodeStat } from 'node:fs/promises';
+import { homedir as nodeHomedir } from 'node:os';
+import { isAbsolute, relative, sep } from 'node:path';
+import {
+  discover,
+  readCredentialFile,
+  type DiscoverOptions,
+} from './discover';
+import type { OAuthCredentials } from './envelope';
+
+export type FileCredentialSource = { kind: 'file'; path: string };
+
+export type CredentialSource =
+  | { kind: 'claude-code' }
+  | FileCredentialSource;
+
+export interface CredentialSourceOptions extends DiscoverOptions {
+  realpathOverride?: typeof nodeRealpath;
+  statOverride?: typeof nodeStat;
+}
+
+async function validateFilePath(
+  filePath: string,
+  options?: CredentialSourceOptions,
+): Promise<string> {
+  const realpathFn = options?.realpathOverride ?? nodeRealpath;
+  const statFn = options?.statOverride ?? nodeStat;
+  const home = options?.homedirOverride ?? nodeHomedir();
+
+  let resolved: string;
+  try {
+    resolved = await realpathFn(filePath);
+  } catch {
+    throw new Error(
+      `Credential source does not exist or cannot be resolved: ${filePath}`,
+    );
+  }
+
+  let realHome: string;
+  try {
+    realHome = await realpathFn(home);
+  } catch {
+    throw new Error(`Home directory cannot be resolved: ${home}`);
+  }
+
+  const relativePath = relative(realHome, resolved);
+  if (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `Credential source resolves outside home directory: ${resolved}`,
+    );
+  }
+
+  let fileStat: Awaited<ReturnType<typeof nodeStat>>;
+  try {
+    fileStat = await statFn(resolved);
+  } catch {
+    throw new Error(`Credential source cannot be inspected: ${resolved}`);
+  }
+  if (!fileStat.isFile()) {
+    throw new Error(`Credential source is not a regular file: ${resolved}`);
+  }
+
+  return resolved;
+}
+
+export async function canonicalizeFileCredentialSource(
+  filePath: string,
+  options?: CredentialSourceOptions,
+): Promise<FileCredentialSource> {
+  return {
+    kind: 'file',
+    path: await validateFilePath(filePath, options),
+  };
+}
+
+export async function loadCredentialSource(
+  source: CredentialSource,
+  options?: CredentialSourceOptions,
+): Promise<OAuthCredentials> {
+  if (source.kind === 'claude-code') {
+    return discover(options);
+  }
+
+  const resolved = await validateFilePath(source.path, options);
+  const credentials = await readCredentialFile(
+    resolved,
+    options?.readFileOverride,
+  );
+  if (credentials === null) {
+    throw new Error(`Credential source no longer exists: ${resolved}`);
+  }
+  return credentials;
+}

--- a/src/oauth/client.ts
+++ b/src/oauth/client.ts
@@ -1,8 +1,7 @@
-import type { RefreshResult, FetchUsageResult, UsageResponse, RateLimitDiagnostics } from './types';
+import type { FetchUsageResult, RateLimitDiagnostics } from './types';
+import { decodeUsageResponse } from './usage';
 
-const REFRESH_URL = 'https://platform.claude.com/v1/oauth/token';
 const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
-const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const BETA_HEADER = 'oauth-2025-04-20';
 const REQUEST_TIMEOUT_MS = 10_000;
 const DEFAULT_RETRY_AFTER_SECONDS = 60;
@@ -35,88 +34,6 @@ function buildRateLimitDiagnostics(headers: Headers): RateLimitDiagnostics {
   };
 }
 
-export async function refresh(
-  refreshToken: string,
-  fetchImpl: typeof fetch = fetch,
-): Promise<RefreshResult> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-
-  let response: Response;
-  try {
-    const body = new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-      client_id: CLIENT_ID,
-    }).toString();
-
-    response = await fetchImpl(REFRESH_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body,
-      signal: controller.signal,
-    });
-  } catch (err: unknown) {
-    clearTimeout(timer);
-    const message = err instanceof Error ? err.message : String(err);
-    return { kind: 'transient', status: 0, message };
-  }
-
-  clearTimeout(timer);
-
-  const status = response.status;
-
-  if (status === 200) {
-    const json = (await response.json()) as {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-    };
-    const expiresAt = Date.now() + json.expires_in * 1000;
-    return {
-      kind: 'success',
-      data: {
-        accessToken: json.access_token,
-        refreshToken: json.refresh_token,
-        expiresAt,
-      },
-    };
-  }
-
-  if (status === 400) {
-    let bodyText = '';
-    try {
-      bodyText = await response.text();
-    } catch {
-      // ignore
-    }
-    if (bodyText.includes('invalid_grant')) {
-      return { kind: 'auth-fatal', reason: 'invalid_grant' };
-    }
-    return { kind: 'transient', status, message: `${status} from token endpoint` };
-  }
-
-  if (status === 401) {
-    return { kind: 'auth-fatal', reason: '401' };
-  }
-
-  if (status === 403) {
-    return { kind: 'cloudflare-blocked', status: 403 };
-  }
-
-  if (status === 429) {
-    return { kind: 'rate-limited', ...buildRateLimitDiagnostics(response.headers) };
-  }
-
-  if (status >= 500) {
-    return { kind: 'transient', status, message: `${status} from token endpoint` };
-  }
-
-  return { kind: 'transient', status, message: `${status} from token endpoint` };
-}
-
 export async function fetchUsage(
   accessToken: string,
   fetchImpl: typeof fetch = fetch,
@@ -124,46 +41,62 @@ export async function fetchUsage(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-  let response: Response;
   try {
-    response = await fetchImpl(USAGE_URL, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'anthropic-beta': BETA_HEADER,
-      },
-      signal: controller.signal,
-    });
-  } catch (err: unknown) {
-    clearTimeout(timer);
-    const message = err instanceof Error ? err.message : String(err);
-    return { kind: 'transient', status: 0, message };
-  }
+    let response: Response;
+    try {
+      response = await fetchImpl(USAGE_URL, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'anthropic-beta': BETA_HEADER,
+        },
+        signal: controller.signal,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { kind: 'transient', status: 0, message };
+    }
 
-  clearTimeout(timer);
+    const status = response.status;
 
-  const status = response.status;
+    if (status === 200) {
+      try {
+        const data = decodeUsageResponse(await response.json());
+        if (data === null) {
+          return {
+            kind: 'transient',
+            status,
+            message: 'Invalid response from usage endpoint',
+          };
+        }
+        return { kind: 'success', data };
+      } catch {
+        return {
+          kind: 'transient',
+          status,
+          message: 'Invalid response from usage endpoint',
+        };
+      }
+    }
 
-  if (status === 200) {
-    const data = (await response.json()) as UsageResponse;
-    return { kind: 'success', data };
-  }
+    if (status === 401) {
+      return { kind: 'auth-fatal', reason: '401' };
+    }
 
-  if (status === 401) {
-    return { kind: 'auth-fatal', reason: '401' };
-  }
+    if (status === 403) {
+      return { kind: 'cloudflare-blocked', status: 403 };
+    }
 
-  if (status === 403) {
-    return { kind: 'cloudflare-blocked', status: 403 };
-  }
+    if (status === 429) {
+      return { kind: 'rate-limited', ...buildRateLimitDiagnostics(response.headers) };
+    }
 
-  if (status === 429) {
-    return { kind: 'rate-limited', ...buildRateLimitDiagnostics(response.headers) };
-  }
+    if (status >= 500) {
+      return { kind: 'transient', status, message: `${status} from usage endpoint` };
+    }
 
-  if (status >= 500) {
     return { kind: 'transient', status, message: `${status} from usage endpoint` };
+  } finally {
+    clearTimeout(timer);
   }
-
-  return { kind: 'transient', status, message: `${status} from usage endpoint` };
 }

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -1,9 +1,3 @@
-export interface OAuthCredentials {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt: number; // epoch ms
-}
-
 export interface UsageBucket {
   utilization: number; // 0 .. 100
   resets_at?: string;  // ISO 8601 from the OAuth API
@@ -30,13 +24,6 @@ export interface RateLimitDiagnostics {
   retryAfterPresent: boolean;
   xShouldRetry: boolean | null;
 }
-
-export type RefreshResult =
-  | { kind: 'success'; data: OAuthCredentials }
-  | { kind: 'auth-fatal'; reason: string }
-  | { kind: 'cloudflare-blocked'; status: number }
-  | ({ kind: 'rate-limited' } & RateLimitDiagnostics)
-  | { kind: 'transient'; status: number; message: string };
 
 export type FetchUsageResult =
   | { kind: 'success'; data: UsageResponse }

--- a/src/oauth/usage.ts
+++ b/src/oauth/usage.ts
@@ -1,0 +1,129 @@
+import type { ExtraUsage, UsageBucket, UsageResponse } from './types';
+
+const INVALID_USAGE_FIELD = Symbol('invalid-usage-field');
+
+interface UsageBucketJson {
+  utilization?: unknown;
+  resets_at?: unknown;
+  resetsAt?: unknown;
+}
+
+interface ExtraUsageJson {
+  is_enabled?: unknown;
+  utilization?: unknown;
+  used_credits?: unknown;
+  monthly_limit?: unknown;
+}
+
+interface UsageResponseJson {
+  five_hour?: unknown;
+  seven_day?: unknown;
+  seven_day_sonnet?: unknown;
+  seven_day_opus?: unknown;
+  extra_usage?: unknown;
+}
+
+function optionalFiniteNumber(
+  value: unknown,
+): number | undefined | typeof INVALID_USAGE_FIELD {
+  if (value === undefined) return undefined;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : INVALID_USAGE_FIELD;
+}
+
+function optionalString(
+  value: unknown,
+): string | undefined | typeof INVALID_USAGE_FIELD {
+  if (value === undefined) return undefined;
+  return typeof value === 'string' ? value : INVALID_USAGE_FIELD;
+}
+
+function decodeUsageBucket(
+  value: unknown,
+): UsageBucket | null | undefined | typeof INVALID_USAGE_FIELD {
+  if (value === undefined || value === null) return value;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return INVALID_USAGE_FIELD;
+  }
+
+  const candidate = value as UsageBucketJson;
+  const utilization = optionalFiniteNumber(candidate.utilization);
+  const resetsAtSnake = optionalString(candidate.resets_at);
+  const resetsAtCamel = optionalString(candidate.resetsAt);
+  if (
+    utilization === undefined ||
+    utilization === INVALID_USAGE_FIELD ||
+    resetsAtSnake === INVALID_USAGE_FIELD ||
+    resetsAtCamel === INVALID_USAGE_FIELD
+  ) {
+    return INVALID_USAGE_FIELD;
+  }
+
+  return {
+    utilization,
+    ...(resetsAtSnake === undefined ? {} : { resets_at: resetsAtSnake }),
+    ...(resetsAtCamel === undefined ? {} : { resetsAt: resetsAtCamel }),
+  };
+}
+
+function decodeExtraUsage(
+  value: unknown,
+): ExtraUsage | undefined | typeof INVALID_USAGE_FIELD {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return INVALID_USAGE_FIELD;
+  }
+
+  const candidate = value as ExtraUsageJson;
+  const utilization = optionalFiniteNumber(candidate.utilization);
+  const usedCredits = optionalFiniteNumber(candidate.used_credits);
+  const monthlyLimit = optionalFiniteNumber(candidate.monthly_limit);
+  if (
+    typeof candidate.is_enabled !== 'boolean' ||
+    utilization === INVALID_USAGE_FIELD ||
+    usedCredits === INVALID_USAGE_FIELD ||
+    monthlyLimit === INVALID_USAGE_FIELD
+  ) {
+    return INVALID_USAGE_FIELD;
+  }
+
+  return {
+    is_enabled: candidate.is_enabled,
+    ...(utilization === undefined ? {} : { utilization }),
+    ...(usedCredits === undefined ? {} : { used_credits: usedCredits }),
+    ...(monthlyLimit === undefined ? {} : { monthly_limit: monthlyLimit }),
+  };
+}
+
+export function decodeUsageResponse(value: unknown): UsageResponse | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const candidate = value as UsageResponseJson;
+  const fiveHour = decodeUsageBucket(candidate.five_hour);
+  const sevenDay = decodeUsageBucket(candidate.seven_day);
+  const sevenDaySonnet = decodeUsageBucket(candidate.seven_day_sonnet);
+  const sevenDayOpus = decodeUsageBucket(candidate.seven_day_opus);
+  const extraUsage = decodeExtraUsage(candidate.extra_usage);
+  if (
+    fiveHour === INVALID_USAGE_FIELD ||
+    sevenDay === INVALID_USAGE_FIELD ||
+    sevenDaySonnet === INVALID_USAGE_FIELD ||
+    sevenDayOpus === INVALID_USAGE_FIELD ||
+    extraUsage === INVALID_USAGE_FIELD
+  ) {
+    return null;
+  }
+
+  return {
+    ...(fiveHour === undefined ? {} : { five_hour: fiveHour }),
+    ...(sevenDay === undefined ? {} : { seven_day: sevenDay }),
+    ...(sevenDaySonnet === undefined
+      ? {}
+      : { seven_day_sonnet: sevenDaySonnet }),
+    ...(sevenDayOpus === undefined ? {} : { seven_day_opus: sevenDayOpus }),
+    ...(extraUsage === undefined ? {} : { extra_usage: extraUsage }),
+  };
+}

--- a/src/subcommands/doctor.ts
+++ b/src/subcommands/doctor.ts
@@ -3,6 +3,10 @@ import {
   defaultDiagnosticLogPath,
   readDiagnosticLog,
 } from '../diagnostics/logger';
+import {
+  rateLimitCooldownRemainingMs,
+  refreshCooldownRemainingMs,
+} from './enterprise-refresh-policy';
 
 export interface DoctorDeps {
   cachePath?: string;
@@ -37,26 +41,31 @@ export async function runDoctor(
 
   if (cache === null) {
     lines.push('cache:         absent or unreadable');
-    lines.push('credential use: unavailable (cache absent)');
-    lines.push('credential origin: not recorded');
+    lines.push('credential source: unavailable (cache absent)');
     lines.push(`diagnostics:   ${logPath}`);
     if (showLogs) {
       const log = await readDiagnosticLog(logPath);
       if (log.length > 0) lines.push('', log.trimEnd());
     }
     lines.push('');
-    lines.push('Re-run `npx @nkootstra/cc-statusline --plan <pro|max|enterprise>` to install.');
+    lines.push('run init to create the cache');
     process.stdout.write(lines.join('\n') + '\n');
     return 0;
   }
 
   const nowMs = now();
-  const cooldownUntilMs = Math.max(cache.rateLimitedUntilMs, cache.nextRefreshAllowedAt);
+  const cooldownRemainingMs = refreshCooldownRemainingMs(cache, nowMs);
+  const rateLimitRemainingMs = rateLimitCooldownRemainingMs(cache, nowMs);
 
   lines.push(`cache:         present (schemaVersion ${cache.schemaVersion})`);
   lines.push(`authState:     ${cache.authState}`);
-  lines.push('credential use: local cache (cache.json)');
-  lines.push('credential origin: not recorded');
+  lines.push(
+    `credential source: ${
+      cache.credentialSource.kind === 'claude-code'
+        ? 'Claude Code'
+        : 'explicit file'
+    }`,
+  );
 
   const lastUsageLabel =
     cache.lastUsageRefreshAt === 0
@@ -65,10 +74,15 @@ export async function runDoctor(
   lines.push(`last usage:    ${lastUsageLabel}`);
 
   const cooldownLabel =
-    cooldownUntilMs > nowMs
-      ? `cooling down ${formatRelativeMs(cooldownUntilMs - nowMs)}`
+    rateLimitRemainingMs > 0
+      ? `cooling down ${formatRelativeMs(rateLimitRemainingMs)}`
       : 'not rate-limited';
   lines.push(`rate limit:    ${cooldownLabel}`);
+  if (cooldownRemainingMs > 0 && rateLimitRemainingMs === 0) {
+    lines.push(
+      `refresh retry: cooling down ${formatRelativeMs(cooldownRemainingMs)}`,
+    );
+  }
 
   lines.push(`refresh:       ${isRefreshInFlight(cache, nowMs) ? 'in flight' : 'idle'}`);
 

--- a/src/subcommands/enterprise-refresh-policy.ts
+++ b/src/subcommands/enterprise-refresh-policy.ts
@@ -1,0 +1,116 @@
+import {
+  isRefreshInFlight,
+  type Cache,
+} from '../cache/store';
+
+const AUTH_RETRY_INTERVAL_MS = 5 * 60 * 1000;
+
+export type RefreshDecisionReason =
+  | 'cache-missing'
+  | 'in-flight'
+  | 'adaptive-backoff'
+  | 'rate-limit-cooldown'
+  | 'retry-cooldown'
+  | 'auth-fatal-retry'
+  | 'auth-fatal-throttled'
+  | 'stale-cache';
+
+export type RefreshDecision =
+  | { action: 'none' }
+  | {
+      action: 'skip' | 'spawn';
+      reason: RefreshDecisionReason;
+      usageAgeMs: number | null;
+      cooldownRemainingMs: number;
+    };
+
+export function refreshCooldownRemainingMs(
+  cache: Cache,
+  nowMs: number,
+): number {
+  return Math.max(
+    0,
+    Math.max(cache.rateLimitedUntilMs, cache.nextRefreshAllowedAt) - nowMs,
+  );
+}
+
+export function rateLimitCooldownRemainingMs(
+  cache: Cache,
+  nowMs: number,
+): number {
+  if (
+    cache.rateLimitedUntilMs <= nowMs &&
+    cache.consecutiveRateLimitCount === 0
+  ) {
+    return 0;
+  }
+  return refreshCooldownRemainingMs(cache, nowMs);
+}
+
+export function decideEnterpriseRefresh(
+  cache: Cache | null,
+  nowMs: number,
+  staleThresholdMs: number,
+): RefreshDecision {
+  if (cache === null) {
+    return {
+      action: 'skip',
+      reason: 'cache-missing',
+      usageAgeMs: null,
+      cooldownRemainingMs: 0,
+    };
+  }
+
+  const usageAgeMs = nowMs - cache.lastUsageRefreshAt;
+  const isStale = usageAgeMs >= staleThresholdMs;
+  const isAuthFatal = cache.authState === 'fatal';
+  if (!isStale && !isAuthFatal) {
+    return { action: 'none' };
+  }
+
+  if (
+    cache.lastRefreshStartedAt !== 0 &&
+    isRefreshInFlight(cache, nowMs)
+  ) {
+    return {
+      action: 'skip',
+      reason: 'in-flight',
+      usageAgeMs,
+      cooldownRemainingMs: 0,
+    };
+  }
+
+  const cooldownRemainingMs = refreshCooldownRemainingMs(cache, nowMs);
+  if (cooldownRemainingMs > 0) {
+    return {
+      action: 'skip',
+      reason:
+        cache.rateLimitedUntilMs > nowMs
+          ? 'rate-limit-cooldown'
+          : cache.consecutiveRateLimitCount > 0
+            ? 'adaptive-backoff'
+            : 'retry-cooldown',
+      usageAgeMs,
+      cooldownRemainingMs,
+    };
+  }
+
+  if (!isAuthFatal) {
+    return {
+      action: 'spawn',
+      reason: 'stale-cache',
+      usageAgeMs,
+      cooldownRemainingMs: 0,
+    };
+  }
+
+  const retryEligible =
+    cache.lastRefreshStartedAt === 0 ||
+    nowMs - cache.lastRefreshStartedAt >= AUTH_RETRY_INTERVAL_MS;
+  return {
+    action: retryEligible ? 'spawn' : 'skip',
+    reason: retryEligible ? 'auth-fatal-retry' : 'auth-fatal-throttled',
+    usageAgeMs,
+    cooldownRemainingMs: 0,
+  };
+}

--- a/src/subcommands/init-enterprise.ts
+++ b/src/subcommands/init-enterprise.ts
@@ -1,0 +1,388 @@
+import type { SpawnSyncOptions } from 'node:child_process';
+import { CredentialNotFoundError, discover } from '../credentials/discover';
+import {
+  canonicalizeFileCredentialSource,
+  loadCredentialSource,
+  type CredentialSource,
+} from '../credentials/source';
+import { readCache, type Cache } from '../cache/store';
+import { fetchUsage } from '../oauth/client';
+import type { OAuthCredentials } from '../credentials/envelope';
+import type {
+  FetchUsageResult,
+  UsageResponse,
+} from '../oauth/types';
+
+const AUTH_STATUS_TIMEOUT_MS = 10_000;
+
+export interface SpawnClaudeResult {
+  status: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout?: string | Buffer | null;
+  error?: NodeJS.ErrnoException;
+}
+
+export type SpawnClaude = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptions,
+) => SpawnClaudeResult;
+
+export interface EnterprisePreparationOptions {
+  cachePath: string;
+  credentialsPath?: string;
+  force: boolean;
+  homedir: string;
+  platform: NodeJS.Platform;
+  canInteract: boolean;
+  discoverFn: typeof discover;
+  discoverOptions: Parameters<typeof discover>[0];
+  spawnClaude: SpawnClaude;
+  now: () => number;
+  fetchImpl?: typeof fetch;
+}
+
+export type EnterprisePreparation =
+  | { kind: 'ready'; cache: Cache | null; reusedExistingCache: boolean }
+  | { kind: 'exit'; code: number };
+
+type CandidateValidation =
+  | { kind: 'success'; usage: UsageResponse }
+  | { kind: 'auth-failure' }
+  | {
+      kind: 'network-failure';
+      result: Exclude<FetchUsageResult, { kind: 'success' | 'auth-fatal' }>;
+    };
+
+interface ClaudeAuthStatusJson {
+  loggedIn?: unknown;
+}
+
+function claudeEnvironment(
+  platform: NodeJS.Platform,
+  homedir: string,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  if (process.env['PATH'] !== undefined) env['PATH'] = process.env['PATH'];
+  if (platform === 'win32') {
+    env['USERPROFILE'] = homedir;
+  } else {
+    env['HOME'] = homedir;
+  }
+  if (process.env['CLAUDE_CONFIG_DIR'] !== undefined) {
+    env['CLAUDE_CONFIG_DIR'] = process.env['CLAUDE_CONFIG_DIR'];
+  }
+  return env;
+}
+
+function loggedInFrom(result: SpawnClaudeResult): boolean | null {
+  if (
+    (result.status !== 0 && result.status !== 1) ||
+    result.stdout === undefined ||
+    result.stdout === null
+  ) {
+    return null;
+  }
+
+  try {
+    const raw = typeof result.stdout === 'string'
+      ? result.stdout
+      : result.stdout.toString('utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    const { loggedIn } = parsed as ClaudeAuthStatusJson;
+    return typeof loggedIn === 'boolean' ? loggedIn : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasUsableCachedCredentials(cache: Cache, now: number): boolean {
+  return (
+    cache.authState === 'ok' &&
+    cache.credentials.accessToken.length > 0 &&
+    Number.isFinite(cache.credentials.expiresAt) &&
+    cache.credentials.expiresAt > now
+  );
+}
+
+async function validateCandidate(
+  credentials: OAuthCredentials,
+  now: number,
+  fetchImpl?: typeof fetch,
+): Promise<CandidateValidation> {
+  if (credentials.expiresAt <= now) {
+    return { kind: 'auth-failure' };
+  }
+
+  const result = await fetchUsage(credentials.accessToken, fetchImpl);
+
+  switch (result.kind) {
+    case 'success':
+      return { kind: 'success', usage: result.data };
+    case 'auth-fatal':
+      return { kind: 'auth-failure' };
+    case 'cloudflare-blocked':
+    case 'rate-limited':
+    case 'transient':
+      return { kind: 'network-failure', result };
+  }
+}
+
+function makeValidatedCache(
+  credentials: OAuthCredentials,
+  source: CredentialSource,
+  usage: UsageResponse,
+  now: number,
+): Cache {
+  return {
+    schemaVersion: 4,
+    authState: 'ok',
+    credentials: {
+      accessToken: credentials.accessToken,
+      expiresAt: credentials.expiresAt,
+    },
+    credentialSource: source,
+    usage,
+    lastUsageRefreshAt: now,
+    lastRefreshStartedAt: 0,
+    lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
+    nextRefreshAllowedAt: 0,
+    consecutiveRateLimitCount: 0,
+  };
+}
+
+function printNetworkFailure(
+  validation: CandidateValidation & { kind: 'network-failure' },
+): void {
+  if (validation.result.kind === 'cloudflare-blocked') {
+    process.stderr.write(
+      'init: credential validation was blocked by Cloudflare.\n' +
+      'Try from a different network or disable any VPN/proxy, then re-run `cc-statusline init`.\n',
+    );
+    return;
+  }
+  if (validation.result.kind === 'rate-limited') {
+    process.stderr.write(
+      'init: credential validation was rate-limited; retry later.\n',
+    );
+    return;
+  }
+  process.stderr.write(
+    'init: could not contact the usage API; retry later.\n',
+  );
+}
+
+function printManualAuthInstructions(): void {
+  process.stderr.write(
+    'init: Claude Code authentication is required. Run:\n' +
+    'claude auth login\n' +
+    'npx @nkootstra/cc-statusline --plan enterprise\n',
+  );
+}
+
+async function recoverAutomaticCredentials(
+  options: EnterprisePreparationOptions,
+): Promise<
+  | { kind: 'success'; credentials: OAuthCredentials; usage: UsageResponse }
+  | { kind: 'exit'; code: number }
+> {
+  let credentials: OAuthCredentials | null = null;
+  try {
+    credentials = await options.discoverFn(options.discoverOptions);
+  } catch (error: unknown) {
+    if (!(error instanceof CredentialNotFoundError)) {
+      process.stderr.write(
+        'init: could not read Claude Code credentials.\n',
+      );
+      return { kind: 'exit', code: 3 };
+    }
+  }
+
+  if (credentials !== null) {
+    const validation = await validateCandidate(
+      credentials,
+      options.now(),
+      options.fetchImpl,
+    );
+    if (validation.kind === 'success') {
+      return { kind: 'success', credentials, usage: validation.usage };
+    }
+    if (validation.kind === 'network-failure') {
+      printNetworkFailure(validation);
+      return { kind: 'exit', code: 4 };
+    }
+  }
+
+  if (!options.canInteract) {
+    printManualAuthInstructions();
+    return { kind: 'exit', code: 2 };
+  }
+
+  const env = claudeEnvironment(options.platform, options.homedir);
+  const status = options.spawnClaude('claude', ['auth', 'status'], {
+    shell: false,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: AUTH_STATUS_TIMEOUT_MS,
+    encoding: 'utf8',
+    env,
+  });
+  const loggedIn = loggedInFrom(status);
+  if (loggedIn === true) {
+    process.stdout.write(
+      'Claude Code reports an active login, but its usage credentials were rejected. Signing in again.\n',
+    );
+  } else if (loggedIn === false) {
+    process.stdout.write('Claude Code is not logged in. Starting login.\n');
+  } else {
+    process.stdout.write(
+      'Could not determine Claude Code login status. Starting login.\n',
+    );
+  }
+
+  const login = options.spawnClaude('claude', ['auth', 'login'], {
+    shell: false,
+    stdio: 'inherit',
+    env,
+  });
+  if (login.signal === 'SIGINT' || login.status === 130) {
+    return { kind: 'exit', code: 130 };
+  }
+  if (
+    (login.signal ?? null) !== null ||
+    login.error !== undefined ||
+    login.status !== 0
+  ) {
+    process.stderr.write(
+      'init: `claude auth login` did not complete successfully.\n',
+    );
+    return { kind: 'exit', code: 3 };
+  }
+
+  try {
+    credentials = await options.discoverFn(options.discoverOptions);
+  } catch {
+    process.stderr.write(
+      'init: Claude Code credentials were not available after login.\n',
+    );
+    return { kind: 'exit', code: 3 };
+  }
+
+  const validation = await validateCandidate(
+    credentials,
+    options.now(),
+    options.fetchImpl,
+  );
+  if (validation.kind === 'auth-failure') {
+    process.stderr.write(
+      'init: credential validation failed after login.\n',
+    );
+    return { kind: 'exit', code: 3 };
+  }
+  if (validation.kind === 'network-failure') {
+    printNetworkFailure(validation);
+    return { kind: 'exit', code: 4 };
+  }
+  return { kind: 'success', credentials, usage: validation.usage };
+}
+
+export async function prepareEnterprise(
+  options: EnterprisePreparationOptions,
+): Promise<EnterprisePreparation> {
+  if (!options.force && options.credentialsPath === undefined) {
+    const existingCache = readCache(options.cachePath);
+    if (
+      existingCache !== null &&
+      hasUsableCachedCredentials(existingCache, options.now())
+    ) {
+      return {
+        kind: 'ready',
+        cache: null,
+        reusedExistingCache: true,
+      };
+    }
+  }
+
+  if (options.credentialsPath !== undefined) {
+    let source: CredentialSource;
+    try {
+      source = await canonicalizeFileCredentialSource(
+        options.credentialsPath,
+        { homedirOverride: options.homedir },
+      );
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`init: ${message}\n`);
+      return { kind: 'exit', code: 2 };
+    }
+
+    let credentials: OAuthCredentials;
+    try {
+      credentials = await loadCredentialSource(source, {
+        homedirOverride: options.homedir,
+      });
+    } catch {
+      process.stderr.write(
+        'init: could not read credentials from --credentials-path.\n',
+      );
+      return { kind: 'exit', code: 2 };
+    }
+
+    const validation = await validateCandidate(
+      credentials,
+      options.now(),
+      options.fetchImpl,
+    );
+    if (validation.kind === 'auth-failure') {
+      process.stderr.write(
+        'init: credential validation failed; credentials are expired or unauthorized.\n',
+      );
+      return { kind: 'exit', code: 3 };
+    }
+    if (validation.kind === 'network-failure') {
+      printNetworkFailure(validation);
+      return { kind: 'exit', code: 4 };
+    }
+
+    return {
+      kind: 'ready',
+      cache: makeValidatedCache(
+        credentials,
+        source,
+        validation.usage,
+        options.now(),
+      ),
+      reusedExistingCache: false,
+    };
+  }
+
+  if (options.platform === 'darwin') {
+    process.stdout.write(
+      'note: macOS may prompt to allow keychain access — choose Always Allow to skip future prompts.\n',
+    );
+  }
+
+  const recovery = await recoverAutomaticCredentials(options);
+  if (recovery.kind === 'exit') return recovery;
+
+  return {
+    kind: 'ready',
+    cache: makeValidatedCache(
+      recovery.credentials,
+      { kind: 'claude-code' },
+      recovery.usage,
+      options.now(),
+    ),
+    reusedExistingCache: false,
+  };
+}
+
+export function printEnterpriseSuccess(): void {
+  process.stdout.write(
+    'Enterprise statusline installed. Restart Claude Code to see usage in the prompt area.\n' +
+    'If Claude Code shows "statusline skipped", accept workspace trust for this project.\n',
+  );
+}

--- a/src/subcommands/init.ts
+++ b/src/subcommands/init.ts
@@ -1,38 +1,27 @@
-/**
- * `init` subcommand — installer wizard.
- *
- * Performs plan-tier branching install flow (Pro/Max or Enterprise),
- * writes the bundled file to ~/.claude/cc-statusline/cc-statusline.js,
- * mutates ~/.claude/settings.json, and (for Enterprise) reads the credential,
- * validates it via the refresh subcommand, and writes the initial cache.
- */
-
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import {
   readSettings,
   setStatusLine,
+  clearStatusLine,
   writeSettings,
   defaultSettingsPath,
+  type SettingsFile,
 } from '../settings/mutator';
-import { discover, CredentialNotFoundError } from '../credentials/discover';
-import { decodeEnvelope, InvalidEnvelopeError } from '../credentials/envelope';
-import { readCache, writeCache, defaultCachePath, type Cache } from '../cache/store';
-import type { OAuthCredentials } from '../oauth/types';
+import { discover } from '../credentials/discover';
+import { writeCache, defaultCachePath } from '../cache/store';
+import {
+  prepareEnterprise,
+  printEnterpriseSuccess,
+  type SpawnClaude,
+} from './init-enterprise';
 
-// ---------------------------------------------------------------------------
-// Version (read from package.json — works in source and in the tsup bundle
-// because tsup processes resolveJsonModule and includes the import inline).
-// Deviation note: if package.json is not accessible at runtime in the bundled
-// binary, we fall back to a compile-time constant extracted here.
-// ---------------------------------------------------------------------------
+export type { SpawnClaudeResult } from './init-enterprise';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const PKG_VERSION: string = ((): string => {
   try {
-    // In source: __dirname is src/subcommands, package.json is two levels up.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const pkg = require('../../package.json') as { version: string };
     return pkg.version;
@@ -41,50 +30,31 @@ const PKG_VERSION: string = ((): string => {
   }
 })();
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 export type PlanTier = 'pro' | 'max' | 'enterprise';
 
-export interface SpawnRefreshResult {
-  status: number | null;
-}
-
 export interface InitDeps {
-  /** Override homedir (for tests). */
   homedirOverride?: string;
-  /** Override platform (for tests). */
   platformOverride?: NodeJS.Platform;
-  /** Override __filename for the bundle copy (for tests). */
   bundlePathOverride?: string;
-  /** Inject a custom refresh-subprocess invoker (for tests). */
-  spawnRefresh?: (args: string[], opts: SpawnSyncOptions) => SpawnRefreshResult;
-  /** Inject a custom discover implementation (for tests). */
   discoverImpl?: typeof discover;
-  /** Single-keystroke reader (for plan prompt) (for tests). */
   stdinReader?: () => Promise<string>;
-  /** No-echo paste reader (for credential paste prompt) (for tests). */
-  pasteReader?: () => Promise<string>;
-  /** Override TTY detection (for tests). */
   isInteractive?: boolean;
-  /** Override the version string emitted in the install log (for tests). */
   versionString?: string;
-  /** Override settings file path (for tests). */
   settingsPath?: string;
-  /** Override cache file path (for tests). */
   cachePath?: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  spawnClaude?: SpawnClaude;
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+type SettingsPreparation =
+  | { kind: 'ready'; shouldWrite: boolean }
+  | { kind: 'exit'; code: number };
 
 function getClaudeDir(homedirOverride?: string): string {
   const configDir = process.env['CLAUDE_CONFIG_DIR'];
   if (configDir) return configDir;
-  const home = homedirOverride ?? os.homedir();
-  return path.join(home, '.claude');
+  return path.join(homedirOverride ?? os.homedir(), '.claude');
 }
 
 function getInstallDir(homedirOverride?: string): string {
@@ -95,17 +65,18 @@ function getBundleDestPath(homedirOverride?: string): string {
   return path.join(getInstallDir(homedirOverride), 'cc-statusline.js');
 }
 
-/** Build the statusLine command string for settings.json. */
-function buildCommand(installDir: string, tier: PlanTier, platform: NodeJS.Platform): string {
+function buildCommand(
+  installDir: string,
+  tier: PlanTier,
+  platform: NodeJS.Platform,
+): string {
   const bundlePath = path.join(installDir, 'cc-statusline.js');
   const subcommand = tier === 'enterprise' ? 'render-enterprise' : 'render-promax';
-  if (platform === 'win32') {
-    return `node ${bundlePath} ${subcommand}`;
-  }
-  return `${bundlePath} ${subcommand}`;
+  return platform === 'win32'
+    ? `node ${bundlePath} ${subcommand}`
+    : `${bundlePath} ${subcommand}`;
 }
 
-/** Read a single keystroke from stdin (raw mode). */
 async function readSingleKeystroke(): Promise<string> {
   return new Promise((resolve) => {
     const stdin = process.stdin;
@@ -125,140 +96,129 @@ async function readSingleKeystroke(): Promise<string> {
   });
 }
 
-/** Read a pasted line from stdin without echoing to stdout. */
-async function readPasteNoEcho(): Promise<string> {
-  return new Promise((resolve) => {
-    const stdin = process.stdin;
-    let buf = '';
+async function choosePlan(
+  planFlag: PlanTier | undefined,
+  canInteract: boolean,
+  stdinReader: () => Promise<string>,
+): Promise<PlanTier | 1 | 130> {
+  if (planFlag !== undefined) return planFlag;
 
-    stdin.resume();
-    stdin.setEncoding('utf8');
-
-    const handler = (chunk: string) => {
-      buf += chunk;
-      // Accept input terminated by newline (Enter key)
-      if (buf.includes('\n')) {
-        stdin.removeListener('data', handler);
-        stdin.pause();
-        resolve(buf.replace(/\n$/, '').trim());
-      }
-    };
-
-    stdin.on('data', handler);
-  });
-}
-
-/** Validate that a credentials path is safe to read. */
-async function validateCredentialsPath(
-  credentialsPath: string,
-  homedir: string,
-): Promise<{ ok: true; resolved: string } | { ok: false; reason: string }> {
-  // 1. Resolve via realpath (verifies the file exists and resolves symlinks)
-  let resolved: string;
-  try {
-    resolved = await fs.promises.realpath(credentialsPath);
-  } catch {
-    return {
-      ok: false,
-      reason: `credentials path does not exist or cannot be resolved: ${credentialsPath}`,
-    };
+  if (!canInteract) {
+    process.stderr.write(
+      'init: --plan is required in non-interactive mode; expected pro, max, or enterprise\n',
+    );
+    return 1;
   }
 
-  // 2. Resolved path must be inside homedir. Also realpath the homedir so
-  // platforms where the homedir contains symlinks (e.g. macOS resolves
-  // /var/folders to /private/var/folders) don't generate false rejections.
-  let realHome: string;
-  try {
-    realHome = await fs.promises.realpath(homedir);
-  } catch {
-    realHome = homedir;
-  }
-  const rel = path.relative(realHome, resolved);
-  if (rel.startsWith('..') || path.isAbsolute(rel)) {
-    return {
-      ok: false,
-      reason: `credentials path resolves outside home directory: ${resolved}`,
-    };
-  }
+  process.stdout.write(
+    'Which Claude Code plan are you on?\n' +
+    '  [1] Pro\n' +
+    '  [2] Max\n' +
+    '  [3] Enterprise (uses keychain credentials)\n' +
+    '  Choice (1-3): ',
+  );
 
-  // 3. Must be a regular file (reject /dev/zero, directories, etc.)
-  try {
-    const stat = fs.statSync(resolved);
-    if (!stat.isFile()) {
-      return {
-        ok: false,
-        reason: `credentials path is not a regular file: ${resolved}`,
-      };
+  for (let attempts = 0; attempts < 10; attempts++) {
+    const key = await stdinReader();
+    if (key === '1') {
+      process.stdout.write('1\n');
+      return 'pro';
     }
-  } catch (err) {
-    return {
-      ok: false,
-      reason: `cannot stat credentials path: ${(err as Error).message}`,
-    };
+    if (key === '2') {
+      process.stdout.write('2\n');
+      return 'max';
+    }
+    if (key === '3') {
+      process.stdout.write('3\n');
+      return 'enterprise';
+    }
+    if (key === '\u0003' || key === '\u0004') {
+      process.stdout.write('\n');
+      return 130;
+    }
   }
 
-  return { ok: true, resolved };
+  process.stderr.write('init: invalid input; expected 1, 2, or 3\n');
+  return 1;
 }
 
-/** Write initial cache for Enterprise flow. */
-async function writeInitialCache(
-  credentials: OAuthCredentials,
-  cachePath: string,
-): Promise<void> {
-  const cache: Cache = {
-    schemaVersion: 3,
-    authState: 'ok',
-    credentials,
-    usage: null,
-    lastUsageRefreshAt: 0,
-    lastRefreshStartedAt: 0,
-    lastErrorMessage: null,
-    rateLimitedUntilMs: 0,
-    nextRefreshAllowedAt: 0,
-    consecutiveRateLimitCount: 0,
-  };
-  await writeCache(cache, cachePath);
+function replaceStatusLine(settings: SettingsFile, command: string): void {
+  clearStatusLine(settings);
+  setStatusLine(settings, command);
 }
 
-/** Default refresh subprocess invoker. */
-function defaultSpawnRefresh(args: string[], opts: SpawnSyncOptions): SpawnRefreshResult {
-  return spawnSync(process.execPath, args, { ...opts, shell: false });
-}
+async function prepareSettings(
+  settings: SettingsFile,
+  command: string,
+  force: boolean,
+  canInteract: boolean,
+  stdinReader: () => Promise<string>,
+): Promise<SettingsPreparation> {
+  const mutation = setStatusLine(settings, command);
+  if (mutation.action === 'no-change') {
+    return { kind: 'ready', shouldWrite: false };
+  }
+  if (mutation.action !== 'conflict') {
+    return { kind: 'ready', shouldWrite: true };
+  }
+  if (force) {
+    replaceStatusLine(settings, command);
+    return { kind: 'ready', shouldWrite: true };
+  }
+  if (!canInteract) {
+    process.stderr.write(
+      `init: settings.json already has a different statusLine.command:\n  ${mutation.existing ?? ''}\n` +
+      'Use --force to overwrite, or uninstall the existing statusline first.\n',
+    );
+    return { kind: 'exit', code: 2 };
+  }
 
-// ---------------------------------------------------------------------------
-// Main entrypoint
-// ---------------------------------------------------------------------------
+  process.stdout.write(
+    `\nExisting statusLine.command: ${mutation.existing ?? ''}\nReplace? (y/n) `,
+  );
+  const answer = await stdinReader();
+  process.stdout.write(`${answer}\n`);
+  if (answer.toLowerCase() !== 'y') {
+    process.stdout.write('Aborted. No changes made.\n');
+    return { kind: 'exit', code: 0 };
+  }
+
+  replaceStatusLine(settings, command);
+  return { kind: 'ready', shouldWrite: true };
+}
 
 export async function runInit(args: string[], deps: InitDeps = {}): Promise<number> {
-  // ── Parse flags ─────────────────────────────────────────────────────────
   let planFlag: PlanTier | undefined;
   let credentialsPathFlag: string | undefined;
   let forceFlag = false;
+  let nonInteractiveFlag = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
     if (arg.startsWith('--plan=')) {
-      const val = arg.slice('--plan='.length).toLowerCase();
-      if (val === 'pro' || val === 'max' || val === 'enterprise') {
-        planFlag = val;
-      } else {
-        process.stderr.write(`init: unknown plan "${val}"; expected pro, max, or enterprise\n`);
+      const value = arg.slice('--plan='.length).toLowerCase();
+      if (value !== 'pro' && value !== 'max' && value !== 'enterprise') {
+        process.stderr.write(
+          `init: unknown plan "${value}"; expected pro, max, or enterprise\n`,
+        );
         return 1;
       }
+      planFlag = value;
     } else if (arg === '--plan') {
-      const val = args[++i]?.toLowerCase();
-      if (val === 'pro' || val === 'max' || val === 'enterprise') {
-        planFlag = val;
-      } else {
-        process.stderr.write(`init: unknown plan "${val ?? ''}"; expected pro, max, or enterprise\n`);
+      const value = args[++i]?.toLowerCase();
+      if (value !== 'pro' && value !== 'max' && value !== 'enterprise') {
+        process.stderr.write(
+          `init: unknown plan "${value ?? ''}"; expected pro, max, or enterprise\n`,
+        );
         return 1;
       }
+      planFlag = value;
     } else if (arg.startsWith('--credentials-path=')) {
       credentialsPathFlag = arg.slice('--credentials-path='.length);
     } else if (arg === '--force') {
       forceFlag = true;
     } else if (arg === '--non-interactive') {
-      // Explicitly setting non-interactive mode; handled via isInteractive below
+      nonInteractiveFlag = true;
     } else {
       process.stderr.write(`init: unknown flag "${arg}"\n`);
       return 1;
@@ -267,129 +227,77 @@ export async function runInit(args: string[], deps: InitDeps = {}): Promise<numb
 
   const platform = deps.platformOverride ?? process.platform;
   const homedir = deps.homedirOverride ?? os.homedir();
-  const bundlePath = deps.bundlePathOverride ?? __filename;
+  const bundleSourcePath = deps.bundlePathOverride ?? __filename;
   const versionString = deps.versionString ?? PKG_VERSION;
-  const spawnRefreshFn = deps.spawnRefresh ?? defaultSpawnRefresh;
   const discoverFn = deps.discoverImpl ?? discover;
   const settingsFilePath = deps.settingsPath ?? defaultSettingsPath();
-  const cachePath = deps.cachePath ?? defaultCachePath();
+  const cacheFilePath = deps.cachePath ?? defaultCachePath();
+  const now = deps.now ?? Date.now;
+  const spawnClaude = deps.spawnClaude ?? spawnSync;
+  const canInteract =
+    !nonInteractiveFlag &&
+    (deps.isInteractive ??
+      (process.stdin.isTTY === true && process.stdout.isTTY === true));
+  const stdinReader = deps.stdinReader ?? readSingleKeystroke;
 
-  // Presence of --plan implies non-interactive
-  const isInteractive = deps.isInteractive ?? (planFlag === undefined && process.stdin.isTTY === true);
+  const tier = await choosePlan(planFlag, canInteract, stdinReader);
+  if (tier === 1 || tier === 130) return tier;
 
-  // ── Determine plan tier ─────────────────────────────────────────────────
-  let tier: PlanTier;
-
-  if (planFlag !== undefined) {
-    tier = planFlag;
-  } else {
-    // Interactive plan selection
-    process.stdout.write(
-      'Which Claude Code plan are you on?\n' +
-      '  [1] Pro\n' +
-      '  [2] Max\n' +
-      '  [3] Enterprise (uses keychain credentials)\n' +
-      '  Choice (1-3): ',
-    );
-
-    const stdinReader = deps.stdinReader ?? readSingleKeystroke;
-    let key: string;
-
-    // Reject keys other than 1, 2, 3
-    let attempts = 0;
-    while (true) {
-      key = await stdinReader();
-      attempts++;
-      if (key === '1') {
-        tier = 'pro';
-        process.stdout.write('1\n');
-        break;
-      } else if (key === '2') {
-        tier = 'max';
-        process.stdout.write('2\n');
-        break;
-      } else if (key === '3') {
-        tier = 'enterprise';
-        process.stdout.write('3\n');
-        break;
-      } else if (key === '' || key === '') {
-        // Ctrl+C / Ctrl+D
-        process.stdout.write('\n');
-        return 130;
-      } else if (attempts >= 10) {
-        process.stderr.write('init: invalid input; expected 1, 2, or 3\n');
-        return 1;
-      }
-      // else re-prompt silently for invalid key
-    }
-  }
-
-  // ── Install directory setup ─────────────────────────────────────────────
   const installDir = getInstallDir(deps.homedirOverride);
-  const destPath = getBundleDestPath(deps.homedirOverride);
-
-  // Create install directory
-  fs.mkdirSync(installDir, { recursive: true, mode: 0o700 });
-
-  // Always re-copy the running bundle
-  fs.copyFileSync(bundlePath, destPath);
-  if (platform !== 'win32') {
-    fs.chmodSync(destPath, 0o755);
-  }
-
-  process.stdout.write(`installed cc-statusline v${versionString} to ${installDir}/cc-statusline.js\n`);
-
-  // ── Settings mutation ───────────────────────────────────────────────────
+  const destinationPath = getBundleDestPath(deps.homedirOverride);
   const command = buildCommand(installDir, tier, platform);
   const settings = readSettings(settingsFilePath);
-  const mutResult = setStatusLine(settings, command);
+  const settingsPreparation = await prepareSettings(
+    settings,
+    command,
+    forceFlag,
+    canInteract,
+    stdinReader,
+  );
+  if (settingsPreparation.kind === 'exit') return settingsPreparation.code;
 
-  if (mutResult.action === 'conflict') {
-    if (forceFlag) {
-      // Overwrite without prompting
-      setStatusLine(settings, command);
-      // We need to force-write: set the statusLine directly
-      settings.statusLine = {
-        type: 'command',
-        command,
-        padding: 2,
-        refreshInterval: 10,
-      };
-      await writeSettings(settingsFilePath, settings);
-    } else if (!isInteractive) {
-      process.stderr.write(
-        `init: settings.json already has a different statusLine.command:\n  ${mutResult.existing ?? ''}\n` +
-        `Use --force to overwrite, or uninstall the existing statusline first.\n`,
-      );
-      return 2;
-    } else {
-      // Interactive conflict prompt
-      process.stdout.write(
-        `\nExisting statusLine.command: ${mutResult.existing ?? ''}\nReplace? (y/n) `,
-      );
-      const stdinReader = deps.stdinReader ?? readSingleKeystroke;
-      const answer = await stdinReader();
-      process.stdout.write(answer + '\n');
-      if (answer.toLowerCase() !== 'y') {
-        process.stdout.write('Aborted. No changes made.\n');
-        return 0;
-      }
-      // User said yes — overwrite
-      settings.statusLine = {
-        type: 'command',
-        command,
-        padding: 2,
-        refreshInterval: 10,
-      };
-      await writeSettings(settingsFilePath, settings);
-    }
-  } else if (mutResult.action !== 'no-change') {
-    // 'created' or 'updated'
+  const enterprisePreparation = tier === 'enterprise'
+    ? await prepareEnterprise({
+        cachePath: cacheFilePath,
+        credentialsPath: credentialsPathFlag,
+        force: forceFlag,
+        homedir,
+        platform,
+        canInteract,
+        discoverFn,
+        discoverOptions: {
+          homedirOverride: deps.homedirOverride,
+          platformOverride: deps.platformOverride,
+        },
+        spawnClaude,
+        now,
+        fetchImpl: deps.fetchImpl,
+      })
+    : null;
+  if (enterprisePreparation?.kind === 'exit') {
+    return enterprisePreparation.code;
+  }
+
+  fs.mkdirSync(installDir, { recursive: true, mode: 0o700 });
+  fs.copyFileSync(bundleSourcePath, destinationPath);
+  if (platform !== 'win32') {
+    fs.chmodSync(destinationPath, 0o755);
+  }
+  if (
+    enterprisePreparation !== null &&
+    enterprisePreparation.kind === 'ready' &&
+    enterprisePreparation.cache !== null
+  ) {
+    await writeCache(enterprisePreparation.cache, cacheFilePath);
+  }
+  if (settingsPreparation.shouldWrite) {
     await writeSettings(settingsFilePath, settings);
   }
-  // 'no-change' → skip write
 
-  // ── Pro/Max branch ──────────────────────────────────────────────────────
+  process.stdout.write(
+    `installed cc-statusline v${versionString} to ${installDir}/cc-statusline.js\n`,
+  );
+
   if (tier === 'pro' || tier === 'max') {
     process.stdout.write(
       'Pro/Max statusline installed. Restart Claude Code to see usage in the prompt area.\n' +
@@ -398,205 +306,12 @@ export async function runInit(args: string[], deps: InitDeps = {}): Promise<numb
     return 0;
   }
 
-  // ── Enterprise branch ───────────────────────────────────────────────────
-
-  // Idempotent re-run check: if valid cache exists and no --force, skip credential discovery
-  if (!forceFlag) {
-    const existingCache = readCache(cachePath);
-    if (existingCache !== null) {
-      const now = Date.now();
-      const credentialsValid =
-        existingCache.authState === 'ok' &&
-        existingCache.credentials.expiresAt > now;
-      if (credentialsValid) {
-        process.stdout.write(
-          'Enterprise statusline is already installed with valid credentials.\n' +
-          'Re-run with --force to re-validate credentials.\n',
-        );
-        process.stdout.write(
-          'Enterprise statusline installed. Restart Claude Code to see usage in the prompt area.\n' +
-          'If Claude Code shows "statusline skipped", accept workspace trust for this project.\n',
-        );
-        return 0;
-      }
-    }
-  }
-
-  // Discover credentials
-  let credentials: OAuthCredentials;
-
-  if (credentialsPathFlag !== undefined) {
-    // Validate and read from the specified path
-    const validation = await validateCredentialsPath(credentialsPathFlag, homedir);
-    if (!validation.ok) {
-      process.stderr.write(`init: ${validation.reason}\n`);
-      return 2;
-    }
-
-    let raw: string;
-    try {
-      raw = fs.readFileSync(validation.resolved, 'utf8');
-    } catch (err) {
-      process.stderr.write(`init: cannot read credentials file: ${(err as Error).message}\n`);
-      return 2;
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      process.stderr.write(`init: credentials file contains invalid JSON: ${validation.resolved}\n`);
-      return 2;
-    }
-
-    try {
-      credentials = decodeEnvelope(parsed);
-    } catch (err) {
-      if (err instanceof InvalidEnvelopeError) {
-        process.stderr.write(`init: invalid credential envelope: ${err.message}\n`);
-        return 2;
-      }
-      throw err;
-    }
-  } else {
-    // Discover from keychain/file
-    if (platform === 'darwin') {
-      process.stdout.write(
-        'note: macOS may prompt to allow keychain access — choose Always Allow to skip future prompts.\n',
-      );
-    }
-
-    try {
-      credentials = await discoverFn({
-        homedirOverride: deps.homedirOverride,
-        platformOverride: deps.platformOverride,
-      });
-    } catch (err) {
-      if (err instanceof CredentialNotFoundError) {
-        if (!isInteractive) {
-          process.stderr.write(
-            `init: no credentials found. Tried:\n  - ${err.pathsTried.join('\n  - ')}\n` +
-            `Provide --credentials-path=<path> or log in to Claude Code first.\n`,
-          );
-          return 2;
-        }
-
-        // Interactive: prompt user to paste credential JSON (max 3 attempts)
-        const pastedCredentials = await (async (): Promise<OAuthCredentials | null> => {
-          for (let attempt = 1; attempt <= 3; attempt++) {
-            process.stdout.write(
-              `\nCredentials not found automatically. Please paste the credential JSON\n` +
-              `(from ~/.claude/.credentials.json or ~/.claude/credentials.json):\n`,
-            );
-
-            const pasteReader = deps.pasteReader ?? readPasteNoEcho;
-            const pasted = await pasteReader();
-
-            let parsedPaste: unknown;
-            try {
-              parsedPaste = JSON.parse(pasted);
-            } catch {
-              if (attempt < 3) {
-                process.stdout.write(`Invalid JSON. Please try again (attempt ${attempt + 1}/3).\n`);
-                continue;
-              }
-              process.stderr.write('init: 3 failed paste attempts; giving up.\n');
-              return null;
-            }
-
-            try {
-              return decodeEnvelope(parsedPaste);
-            } catch (envelopeErr) {
-              if (attempt < 3) {
-                process.stdout.write(
-                  `Invalid credential envelope: ${(envelopeErr as Error).message}. ` +
-                  `Please try again (attempt ${attempt + 1}/3).\n`,
-                );
-                continue;
-              }
-              process.stderr.write('init: 3 failed paste attempts; giving up.\n');
-              return null;
-            }
-          }
-          return null;
-        })();
-
-        if (pastedCredentials === null) {
-          return 2;
-        }
-        credentials = pastedCredentials;
-      } else if (err instanceof InvalidEnvelopeError) {
-        process.stderr.write(`init: invalid credential envelope: ${(err as Error).message}\n`);
-        return 2;
-      } else {
-        throw err;
-      }
-    }
-  }
-
-  // Write initial cache
-  await writeInitialCache(credentials, cachePath);
-
-  // Validate via refresh subprocess
-  const minimalEnv: Record<string, string> = {};
-  if (process.env['PATH'] !== undefined) minimalEnv['PATH'] = process.env['PATH'];
-  if (platform === 'win32') {
-    if (process.env['USERPROFILE'] !== undefined) minimalEnv['USERPROFILE'] = process.env['USERPROFILE'];
-  } else {
-    if (process.env['HOME'] !== undefined) minimalEnv['HOME'] = process.env['HOME'];
-  }
-  if (process.env['CLAUDE_CONFIG_DIR'] !== undefined) {
-    minimalEnv['CLAUDE_CONFIG_DIR'] = process.env['CLAUDE_CONFIG_DIR'];
-  }
-
-  const spawnResult = spawnRefreshFn([bundlePath, 'refresh'], {
-    stdio: 'ignore',
-    env: minimalEnv,
-  });
-
-  void spawnResult; // status code from refresh subprocess is not critical
-
-  // Re-read cache to inspect authState after refresh
-  const postRefreshCache = readCache(cachePath);
-
-  if (postRefreshCache === null) {
-    process.stderr.write('init: cache not found after refresh subprocess; something went wrong.\n');
-    return 3;
-  }
-
-  if (postRefreshCache.authState === 'fatal') {
-    process.stderr.write(
-      'init: credential validation failed (auth-fatal).\n' +
-      'Your credentials may be expired or revoked.\n' +
-      'Please log in to Claude Code again and re-run `cc-statusline init`.\n',
-    );
-    return 3;
-  }
-
-  if (postRefreshCache.authState === 'cloudflare-blocked') {
-    process.stderr.write(
-      'init: credential validation was blocked by Cloudflare.\n' +
-      'Your network may be filtering traffic to platform.claude.com.\n' +
-      'Try from a different network or disable any VPN/proxy, then re-run `cc-statusline init`.\n',
-    );
-    return 3;
-  }
-
-  // authState === 'ok'
-  if (postRefreshCache.usage === null && postRefreshCache.lastErrorMessage !== null) {
+  if (enterprisePreparation?.reusedExistingCache === true) {
     process.stdout.write(
-      'could not contact the usage API; retry later\n',
+      'Enterprise statusline is already installed with valid credentials.\n' +
+      'Re-run with --force to re-validate credentials.\n',
     );
-    process.stdout.write(
-      'Enterprise statusline installed. Restart Claude Code to see usage in the prompt area.\n' +
-      'If Claude Code shows "statusline skipped", accept workspace trust for this project.\n',
-    );
-    return 4;
   }
-
-  process.stdout.write(
-    'Enterprise statusline installed. Restart Claude Code to see usage in the prompt area.\n' +
-    'If Claude Code shows "statusline skipped", accept workspace trust for this project.\n',
-  );
+  printEnterpriseSuccess();
   return 0;
 }

--- a/src/subcommands/refresh.ts
+++ b/src/subcommands/refresh.ts
@@ -1,24 +1,50 @@
 import {
-  readCache,
-  writeCache,
+  updateCache,
   isRefreshInFlight,
   sanitizeErrorMessage,
   defaultCachePath,
   type Cache,
+  type CachedCredentials,
 } from '../cache/store';
-import { refresh, fetchUsage } from '../oauth/client';
+import {
+  loadCredentialSource,
+  type CredentialSource,
+} from '../credentials/source';
+import { fetchUsage } from '../oauth/client';
 import {
   createDiagnosticLogger,
   defaultDiagnosticLogPath,
   type DiagnosticLogger,
 } from '../diagnostics/logger';
+import type { OAuthCredentials } from '../credentials/envelope';
 import type {
   FetchUsageResult,
   RateLimitDiagnostics,
-  RefreshResult,
 } from '../oauth/types';
+import { refreshCooldownRemainingMs } from './enterprise-refresh-policy';
 
-function formatRateLimitMessage(prefix: string, diag: RateLimitDiagnostics): string {
+const SOURCE_RELOAD_THRESHOLD_MS = 5 * 60 * 1000;
+const FAILURE_RETRY_DELAY_MS = 60 * 1000;
+const RATE_LIMIT_BACKOFF_MAX_MS = 5 * 60 * 1000;
+const RATE_LIMIT_BACKOFF_CAP_EXPONENT = 6;
+
+type SourceReloadReason = 'near-expiry' | 'auth-fatal' | 'usage-401';
+type LoadCredentialSource = (
+  source: CredentialSource,
+) => Promise<OAuthCredentials>;
+
+export interface RefreshDeps {
+  cachePath?: string;
+  logPath?: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  loadCredentialSourceImpl?: LoadCredentialSource;
+}
+
+function formatRateLimitMessage(
+  prefix: string,
+  diag: RateLimitDiagnostics,
+): string {
   const headerNote = diag.retryAfterPresent
     ? 'header present'
     : 'header absent, default applied';
@@ -29,57 +55,39 @@ function formatRateLimitMessage(prefix: string, diag: RateLimitDiagnostics): str
   return `${prefix} Retry-After: ${diag.retryAfterSeconds}s (${headerNote}).${shouldRetryNote}`;
 }
 
-export interface RefreshDeps {
-  cachePath?: string;
-  logPath?: string;
-  fetchImpl?: typeof fetch;
-  now?: () => number;
-}
-
-type RequestEndpoint = 'token' | 'usage';
-type RequestResult = RefreshResult | FetchUsageResult;
-const RATE_LIMIT_BACKOFF_MAX_MS = 5 * 60 * 1000; // 5 minutes
-const RATE_LIMIT_BACKOFF_CAP_EXPONENT = 6; // max ×64
-
 function nextRateLimitCooldownUntil(
   nowMs: number,
   retryAfterSeconds: number,
   consecutiveCount: number,
 ): number {
   const baseMs = retryAfterSeconds * 1000;
-  const exponent = Math.min(consecutiveCount + 2, RATE_LIMIT_BACKOFF_CAP_EXPONENT);
+  const exponent = Math.min(
+    consecutiveCount + 2,
+    RATE_LIMIT_BACKOFF_CAP_EXPONENT,
+  );
   const adaptiveMs = baseMs * (1 << exponent);
-  const delayMs = Math.min(adaptiveMs, RATE_LIMIT_BACKOFF_MAX_MS);
-  return nowMs + delayMs;
+  return nowMs + Math.min(adaptiveMs, RATE_LIMIT_BACKOFF_MAX_MS);
 }
 
-function getRefreshCooldownUntilMs(cache: Cache, nowMs: number): number {
-  return Math.max(0, Math.max(cache.rateLimitedUntilMs, cache.nextRefreshAllowedAt) - nowMs);
-}
-
-function statusForResult(endpoint: RequestEndpoint, result: RequestResult): number | undefined {
+function statusForResult(result: FetchUsageResult): number | undefined {
   if (result.kind === 'success') return 200;
   if (result.kind === 'rate-limited') return 429;
-  if (result.kind === 'auth-fatal') {
-    if (result.reason === '401') return 401;
-    if (endpoint === 'token' && result.reason === 'invalid_grant') return 400;
-    return undefined;
-  }
+  if (result.kind === 'auth-fatal') return 401;
   return result.status;
 }
 
-async function logRequestResult(
+async function logUsageResult(
   logger: DiagnosticLogger,
-  endpoint: RequestEndpoint,
-  result: RequestResult,
+  result: FetchUsageResult,
   durationMs: number,
-  credentials: Cache['credentials'],
+  credentials: CachedCredentials,
+  candidate?: OAuthCredentials,
 ): Promise<void> {
   const details: Record<string, unknown> = {
     event: 'http.result',
-    endpoint,
+    endpoint: 'usage',
     result: result.kind,
-    status: statusForResult(endpoint, result),
+    status: statusForResult(result),
     durationMs,
   };
 
@@ -88,267 +96,504 @@ async function logRequestResult(
     details['retryAfterPresent'] = result.retryAfterPresent;
     details['xShouldRetry'] = result.xShouldRetry;
   } else if (result.kind === 'transient') {
-    details['error'] = sanitizeErrorMessage(result.message, credentials);
+    details['error'] = sanitizeErrorMessage(
+      result.message,
+      credentials,
+      candidate,
+    );
   } else if (result.kind === 'auth-fatal') {
-    details['reason'] = sanitizeErrorMessage(result.reason, credentials);
+    details['reason'] = sanitizeErrorMessage(
+      result.reason,
+      credentials,
+      candidate,
+    );
   }
 
   await logger.log(details);
 }
 
+async function requestUsage(
+  accessToken: string,
+  cachedCredentials: CachedCredentials,
+  logger: DiagnosticLogger,
+  fetchImpl?: typeof fetch,
+  candidate?: OAuthCredentials,
+): Promise<FetchUsageResult> {
+  await logger.log({ event: 'http.request', endpoint: 'usage' });
+  const startedAt = performance.now();
+  const result = await fetchUsage(accessToken, fetchImpl);
+  await logUsageResult(
+    logger,
+    result,
+    Math.round(performance.now() - startedAt),
+    cachedCredentials,
+    candidate,
+  );
+  return result;
+}
+
+async function reloadSource(
+  cache: Cache,
+  reason: SourceReloadReason,
+  loadSource: LoadCredentialSource,
+  logger: DiagnosticLogger,
+): Promise<
+  | { kind: 'success'; credentials: OAuthCredentials }
+  | { kind: 'failure'; message: string }
+> {
+  await logger.log({
+    event: 'credential-source.reload.decision',
+    action: 'reload',
+    reason,
+    source: cache.credentialSource.kind,
+  });
+
+  try {
+    const credentials = await loadSource(cache.credentialSource);
+    await logger.log({
+      event: 'credential-source.reload.result',
+      result: 'success',
+      accessTokenChanged:
+        credentials.accessToken !== cache.credentials.accessToken,
+      expiryAdvanced:
+        credentials.expiresAt > cache.credentials.expiresAt,
+    });
+    return { kind: 'success', credentials };
+  } catch (err: unknown) {
+    const rawMessage = err instanceof Error ? err.message : String(err);
+    const message = sanitizeErrorMessage(rawMessage, cache.credentials);
+    await logger.log({
+      event: 'credential-source.reload.result',
+      result: 'failure',
+      error: message,
+    });
+    return { kind: 'failure', message };
+  }
+}
+
+function candidateCredentials(
+  latest: CachedCredentials,
+  candidate: OAuthCredentials,
+): CachedCredentials {
+  if (
+    latest.accessToken === candidate.accessToken &&
+    latest.expiresAt >= candidate.expiresAt
+  ) {
+    return latest;
+  }
+  return {
+    accessToken: candidate.accessToken,
+    expiresAt: candidate.expiresAt,
+  };
+}
+
+function credentialsMatch(
+  left: CachedCredentials,
+  right: CachedCredentials,
+): boolean {
+  return (
+    left.accessToken === right.accessToken &&
+    left.expiresAt === right.expiresAt
+  );
+}
+
+async function updateOwnedCache(
+  cachePath: string,
+  startingCredentials: CachedCredentials,
+  startedAt: number,
+  mutate: (current: Cache) => void,
+): Promise<boolean> {
+  return updateCache(cachePath, (current) => {
+    if (
+      current === null ||
+      current.lastRefreshStartedAt !== startedAt ||
+      !credentialsMatch(current.credentials, startingCredentials)
+    ) {
+      return { kind: 'skip', value: false };
+    }
+    mutate(current);
+    return { kind: 'write', cache: current, value: true };
+  });
+}
+
+async function persistSourceFailure(
+  startingCredentials: CachedCredentials,
+  startedAt: number,
+  cachePath: string,
+  message: string,
+  now: () => number,
+): Promise<boolean> {
+  return updateOwnedCache(
+    cachePath,
+    startingCredentials,
+    startedAt,
+    (current) => {
+      current.lastErrorMessage = sanitizeErrorMessage(
+        message,
+        current.credentials,
+      );
+      current.rateLimitedUntilMs = 0;
+      current.nextRefreshAllowedAt = now() + FAILURE_RETRY_DELAY_MS;
+      current.consecutiveRateLimitCount = 0;
+    },
+  );
+}
+
+async function persistFinal401(
+  startingCredentials: CachedCredentials,
+  startedAt: number,
+  cachePath: string,
+  reason: string,
+  candidate?: OAuthCredentials,
+): Promise<boolean> {
+  return updateOwnedCache(
+    cachePath,
+    startingCredentials,
+    startedAt,
+    (current) => {
+      current.authState = 'fatal';
+      current.lastErrorMessage = sanitizeErrorMessage(
+        `Usage fetch auth-fatal: ${reason}`,
+        current.credentials,
+        candidate,
+      );
+    },
+  );
+}
+
+async function persistNonSuccess(
+  startingCredentials: CachedCredentials,
+  startedAt: number,
+  cachePath: string,
+  result: Exclude<FetchUsageResult, { kind: 'success' | 'auth-fatal' }>,
+  now: () => number,
+  candidate?: OAuthCredentials,
+): Promise<boolean> {
+  return updateOwnedCache(
+    cachePath,
+    startingCredentials,
+    startedAt,
+    (current) => {
+      switch (result.kind) {
+        case 'cloudflare-blocked':
+          current.authState = 'cloudflare-blocked';
+          current.lastErrorMessage = sanitizeErrorMessage(
+            `Usage fetch blocked by Cloudflare (status ${result.status}). ` +
+              'Your network may be filtering traffic to api.anthropic.com.',
+            current.credentials,
+            candidate,
+          );
+          current.rateLimitedUntilMs = 0;
+          current.nextRefreshAllowedAt = now() + FAILURE_RETRY_DELAY_MS;
+          current.consecutiveRateLimitCount = 0;
+          break;
+
+        case 'rate-limited': {
+          const observedAt = now();
+          current.lastErrorMessage = sanitizeErrorMessage(
+            formatRateLimitMessage('Usage fetch rate-limited.', result),
+            current.credentials,
+            candidate,
+          );
+          current.rateLimitedUntilMs =
+            observedAt + result.retryAfterSeconds * 1000;
+          current.nextRefreshAllowedAt = nextRateLimitCooldownUntil(
+            observedAt,
+            result.retryAfterSeconds,
+            current.consecutiveRateLimitCount,
+          );
+          current.consecutiveRateLimitCount += 1;
+          break;
+        }
+
+        case 'transient':
+          current.lastErrorMessage = sanitizeErrorMessage(
+            result.message,
+            current.credentials,
+            candidate,
+          );
+          current.rateLimitedUntilMs = 0;
+          current.nextRefreshAllowedAt = now() + FAILURE_RETRY_DELAY_MS;
+          current.consecutiveRateLimitCount = 0;
+          break;
+      }
+    },
+  );
+}
+
+async function persistSuccess(
+  startingCredentials: CachedCredentials,
+  startedAt: number,
+  cachePath: string,
+  result: Extract<FetchUsageResult, { kind: 'success' }>,
+  now: () => number,
+  candidate?: OAuthCredentials,
+): Promise<boolean> {
+  return updateOwnedCache(
+    cachePath,
+    startingCredentials,
+    startedAt,
+    (current) => {
+      if (candidate !== undefined) {
+        current.credentials = candidateCredentials(
+          current.credentials,
+          candidate,
+        );
+      }
+
+      current.usage = result.data;
+      current.lastUsageRefreshAt = now();
+      current.lastErrorMessage = null;
+      current.authState = 'ok';
+      current.rateLimitedUntilMs = 0;
+      current.nextRefreshAllowedAt = 0;
+      current.consecutiveRateLimitCount = 0;
+    },
+  );
+}
+
+type RefreshClaim =
+  | { kind: 'claimed'; cache: Cache; startedAt: number }
+  | {
+      kind: 'skipped';
+      reason:
+        | 'cache-missing'
+        | 'rate-limit-cooldown'
+        | 'in-flight'
+        | 'claim-lost';
+      cooldownRemainingMs?: number;
+    };
+
+function inheritedClaimFrom(args: string[]): number | null {
+  const prefix = '--claimed-at=';
+  const argument = args.find((value) => value.startsWith(prefix));
+  if (argument === undefined) return null;
+
+  const claimedAt = Number(argument.slice(prefix.length));
+  return Number.isSafeInteger(claimedAt) && claimedAt > 0
+    ? claimedAt
+    : null;
+}
+
 export async function runRefresh(
-  _args: string[],
+  args: string[],
   deps: RefreshDeps = {},
 ): Promise<number> {
   const cachePath = deps.cachePath ?? defaultCachePath();
   const logPath = deps.logPath ?? defaultDiagnosticLogPath(cachePath);
-  const fetchImpl = deps.fetchImpl;
   const now = deps.now ?? (() => Date.now());
   const logger = createDiagnosticLogger(logPath, { now });
+  const loadSource =
+    deps.loadCredentialSourceImpl ??
+    ((source: CredentialSource) => loadCredentialSource(source));
+  const inheritedClaim = inheritedClaimFrom(args);
 
   try {
-    // Step 1: Read cache. If null → exit 0 silently.
-    const initialCache = readCache(cachePath);
-    if (initialCache === null) {
-      await logger.log({ event: 'refresh.skipped', reason: 'cache-missing' });
-      return 0;
-    }
+    const claim = await updateCache<RefreshClaim>(cachePath, (current) => {
+      if (current === null) {
+        return {
+          kind: 'skip',
+          value: { kind: 'skipped', reason: 'cache-missing' },
+        };
+      }
 
-    // Step 2: If authState is 'fatal' → exit 0 silently.
-    if (initialCache.authState === 'fatal') {
-      await logger.log({ event: 'refresh.skipped', reason: 'auth-fatal' });
-      return 0;
-    }
+      if (inheritedClaim !== null) {
+        if (current.lastRefreshStartedAt !== inheritedClaim) {
+          return {
+            kind: 'skip',
+            value: { kind: 'skipped', reason: 'claim-lost' },
+          };
+        }
+        return {
+          kind: 'skip',
+          value: {
+            kind: 'claimed',
+            cache: current,
+            startedAt: inheritedClaim,
+          },
+        };
+      }
 
-    // Step 2b: If still in rate-limit cooldown → exit silently. The renderer
-    // also gates on this, but a stale install or a different code path could
-    // still fire refresh, so guard here too.
-    const cooldownRemainingMs = getRefreshCooldownUntilMs(initialCache, now());
-    if (cooldownRemainingMs > 0) {
+      const observedAt = now();
+      const cooldownRemainingMs = refreshCooldownRemainingMs(
+        current,
+        observedAt,
+      );
+      if (cooldownRemainingMs > 0) {
+        return {
+          kind: 'skip',
+          value: {
+            kind: 'skipped',
+            reason: 'rate-limit-cooldown',
+            cooldownRemainingMs,
+          },
+        };
+      }
+      if (isRefreshInFlight(current, observedAt)) {
+        return {
+          kind: 'skip',
+          value: { kind: 'skipped', reason: 'in-flight' },
+        };
+      }
+
+      const cache = {
+        ...current,
+        lastRefreshStartedAt: observedAt,
+      };
+      return {
+        kind: 'write',
+        cache,
+        value: { kind: 'claimed', cache, startedAt: observedAt },
+      };
+    });
+
+    if (claim.kind === 'skipped') {
       await logger.log({
         event: 'refresh.skipped',
-        reason: 'rate-limit-cooldown',
-        cooldownRemainingMs,
+        reason: claim.reason,
+        ...(claim.cooldownRemainingMs === undefined
+          ? {}
+          : { cooldownRemainingMs: claim.cooldownRemainingMs }),
       });
       return 0;
     }
 
-    // Step 3: Compare-and-swap dedup.
-    // Re-read to get latest state for the in-flight check.
-    const casCache = readCache(cachePath);
-    if (casCache === null) {
-      return 0;
-    }
-
-    if (isRefreshInFlight(casCache, now())) {
-      await logger.log({ event: 'refresh.skipped', reason: 'in-flight' });
-      return 0;
-    }
-
-    // Mark refresh as in-flight by writing lastRefreshStartedAt.
-    const startedAt = now();
-    casCache.lastRefreshStartedAt = startedAt;
-    await writeCache(casCache, cachePath);
-
-    // Re-read to verify we won the CAS race.
-    const verifyCache = readCache(cachePath);
-    if (
-      verifyCache === null ||
-      verifyCache.lastRefreshStartedAt !== startedAt
-    ) {
-      // Another process overwrote our write; exit silently.
-      await logger.log({ event: 'refresh.skipped', reason: 'cas-lost' });
-      return 0;
-    }
-
-    // Work with a mutable copy of the verified cache.
-    let cache: Cache = verifyCache;
+    const { cache, startedAt } = claim;
+    const startingCredentials = { ...cache.credentials };
     await logger.log({ event: 'refresh.started' });
 
-    // Step 4: Token refresh decision.
-    const FIVE_MINUTES_MS = 5 * 60 * 1000;
-    let tokenJustRotated = false;
+    let candidate: OAuthCredentials | undefined;
+    const needsSourceReload =
+      cache.authState === 'fatal' ||
+      cache.credentials.expiresAt - now() < SOURCE_RELOAD_THRESHOLD_MS;
 
-    if (cache.credentials.expiresAt - now() < FIVE_MINUTES_MS) {
-      // Token is near expiry or already expired — refresh it.
-      await logger.log({
-        event: 'token.refresh.decision',
-        action: 'refresh',
-        expiresInMs: cache.credentials.expiresAt - now(),
-      });
-      const refreshArgs: Parameters<typeof refresh> = fetchImpl
-        ? [cache.credentials.refreshToken, fetchImpl]
-        : [cache.credentials.refreshToken];
-      await logger.log({ event: 'http.request', endpoint: 'token' });
-      const requestStartedAt = performance.now();
-      const result = await refresh(...refreshArgs);
-      await logRequestResult(
+    if (needsSourceReload) {
+      const reason: SourceReloadReason =
+        cache.authState === 'fatal' ? 'auth-fatal' : 'near-expiry';
+      const loaded = await reloadSource(
+        cache,
+        reason,
+        loadSource,
         logger,
-        'token',
-        result,
-        Math.round(performance.now() - requestStartedAt),
-        cache.credentials,
       );
-
-      switch (result.kind) {
-        case 'auth-fatal': {
-          const msg = sanitizeErrorMessage(
-            `Token refresh failed: ${result.reason}`,
-            cache.credentials,
-          );
-          cache.authState = 'fatal';
-          cache.lastErrorMessage = msg;
-          await writeCache(cache, cachePath);
-          await logger.log({ event: 'refresh.completed', outcome: 'auth-fatal' });
-          return 0;
-        }
-
-        case 'cloudflare-blocked': {
-          const msg = sanitizeErrorMessage(
-            `Token refresh blocked by Cloudflare (status ${result.status}). ` +
-              'Your network may be filtering traffic to platform.claude.com.',
-            cache.credentials,
-          );
-          cache.authState = 'cloudflare-blocked';
-          cache.lastErrorMessage = msg;
-          await writeCache(cache, cachePath);
-          await logger.log({ event: 'refresh.completed', outcome: 'cloudflare-blocked' });
-          return 0;
-        }
-
-        case 'rate-limited': {
-          const msg = sanitizeErrorMessage(
-            formatRateLimitMessage('Token refresh rate-limited.', result),
-            cache.credentials,
-          );
-          const nextRefreshAllowedAt = nextRateLimitCooldownUntil(
-            now(),
-            result.retryAfterSeconds,
-            cache.consecutiveRateLimitCount,
-          );
-          cache.lastErrorMessage = msg;
-          cache.rateLimitedUntilMs = now() + result.retryAfterSeconds * 1000;
-          cache.nextRefreshAllowedAt = nextRefreshAllowedAt;
-          cache.consecutiveRateLimitCount += 1;
-          await writeCache(cache, cachePath);
-          await logger.log({
-            event: 'refresh.completed',
-            outcome: 'rate-limited',
-            cooldownUntilMs: Math.max(cache.rateLimitedUntilMs, cache.nextRefreshAllowedAt),
-          });
-          return 0;
-        }
-
-        case 'transient': {
-          const msg = sanitizeErrorMessage(result.message, cache.credentials);
-          cache.lastErrorMessage = msg;
-          await writeCache(cache, cachePath);
-          await logger.log({ event: 'refresh.completed', outcome: 'transient' });
-          return 0;
-        }
-
-        case 'success': {
-          cache.credentials = result.data;
-          tokenJustRotated = true;
-          break;
-        }
-      }
-    } else {
-      await logger.log({ event: 'token.refresh.decision', action: 'skip', reason: 'token-fresh' });
-    }
-
-    // Step 5: Fetch usage.
-    const usageArgs: Parameters<typeof fetchUsage> = fetchImpl
-      ? [cache.credentials.accessToken, fetchImpl]
-      : [cache.credentials.accessToken];
-    await logger.log({ event: 'http.request', endpoint: 'usage' });
-    const usageRequestStartedAt = performance.now();
-    const usageResult = await fetchUsage(...usageArgs);
-    await logRequestResult(
-      logger,
-      'usage',
-      usageResult,
-      Math.round(performance.now() - usageRequestStartedAt),
-      cache.credentials,
-    );
-
-    switch (usageResult.kind) {
-      case 'auth-fatal': {
-        const baseMsg = tokenJustRotated
-          ? `Usage fetch failed after token rotation (server-side revocation?): ${usageResult.reason}`
-          : `Usage fetch auth-fatal: ${usageResult.reason}`;
-        const msg = sanitizeErrorMessage(baseMsg, cache.credentials);
-        cache.authState = 'fatal';
-        cache.lastErrorMessage = msg;
-        await writeCache(cache, cachePath);
-        await logger.log({ event: 'refresh.completed', outcome: 'auth-fatal' });
-        return 0;
-      }
-
-      case 'cloudflare-blocked': {
-        const msg = sanitizeErrorMessage(
-          `Usage fetch blocked by Cloudflare (status ${usageResult.status}). ` +
-            'Your network may be filtering traffic to api.anthropic.com.',
-          cache.credentials,
+      if (loaded.kind === 'failure') {
+        const persisted = await persistSourceFailure(
+          startingCredentials,
+          startedAt,
+          cachePath,
+          loaded.message,
+          now,
         );
-        cache.authState = 'cloudflare-blocked';
-        cache.lastErrorMessage = msg;
-        await writeCache(cache, cachePath);
-        await logger.log({ event: 'refresh.completed', outcome: 'cloudflare-blocked' });
-        return 0;
-      }
-
-      case 'rate-limited': {
-        const msg = sanitizeErrorMessage(
-          formatRateLimitMessage('Usage fetch rate-limited.', usageResult),
-          cache.credentials,
-        );
-        const nextRefreshAllowedAt = nextRateLimitCooldownUntil(
-          now(),
-          usageResult.retryAfterSeconds,
-          cache.consecutiveRateLimitCount,
-        );
-        cache.lastErrorMessage = msg;
-        cache.rateLimitedUntilMs = now() + usageResult.retryAfterSeconds * 1000;
-        cache.nextRefreshAllowedAt = nextRefreshAllowedAt;
-        cache.consecutiveRateLimitCount += 1;
-        await writeCache(cache, cachePath);
         await logger.log({
           event: 'refresh.completed',
-          outcome: 'rate-limited',
-          cooldownUntilMs: Math.max(cache.rateLimitedUntilMs, cache.nextRefreshAllowedAt),
+          outcome: persisted ? 'source-failure' : 'stale-discarded',
+        });
+        return 0;
+      }
+      candidate = loaded.credentials;
+    } else {
+      await logger.log({
+        event: 'credential-source.reload.decision',
+        action: 'skip',
+        reason: 'credential-fresh',
+      });
+    }
+
+    let usageResult = await requestUsage(
+      candidate?.accessToken ?? cache.credentials.accessToken,
+      cache.credentials,
+      logger,
+      deps.fetchImpl,
+      candidate,
+    );
+
+    if (usageResult.kind === 'auth-fatal' && candidate === undefined) {
+      const loaded = await reloadSource(
+        cache,
+        'usage-401',
+        loadSource,
+        logger,
+      );
+      if (loaded.kind === 'failure') {
+        const persisted = await persistFinal401(
+          startingCredentials,
+          startedAt,
+          cachePath,
+          usageResult.reason,
+        );
+        await logger.log({
+          event: 'refresh.completed',
+          outcome: persisted ? 'auth-fatal' : 'stale-discarded',
         });
         return 0;
       }
 
+      candidate = loaded.credentials;
+      if (
+        candidate.accessToken !== cache.credentials.accessToken
+      ) {
+        usageResult = await requestUsage(
+          candidate.accessToken,
+          cache.credentials,
+          logger,
+          deps.fetchImpl,
+          candidate,
+        );
+      }
+    }
+
+    switch (usageResult.kind) {
+      case 'auth-fatal': {
+        const persisted = await persistFinal401(
+          startingCredentials,
+          startedAt,
+          cachePath,
+          usageResult.reason,
+          candidate,
+        );
+        await logger.log({
+          event: 'refresh.completed',
+          outcome: persisted ? 'auth-fatal' : 'stale-discarded',
+        });
+        return 0;
+      }
+
+      case 'cloudflare-blocked':
+      case 'rate-limited':
       case 'transient': {
-        const msg = sanitizeErrorMessage(usageResult.message, cache.credentials);
-        cache.lastErrorMessage = msg;
-        await writeCache(cache, cachePath);
-        await logger.log({ event: 'refresh.completed', outcome: 'transient' });
+        const persisted = await persistNonSuccess(
+          startingCredentials,
+          startedAt,
+          cachePath,
+          usageResult,
+          now,
+          candidate,
+        );
+        await logger.log({
+          event: 'refresh.completed',
+          outcome: persisted ? usageResult.kind : 'stale-discarded',
+        });
         return 0;
       }
 
       case 'success': {
-        cache.usage = usageResult.data;
-        cache.lastUsageRefreshAt = now();
-        cache.lastErrorMessage = null;
-        cache.authState = 'ok';
-        cache.rateLimitedUntilMs = 0;
-        cache.nextRefreshAllowedAt = 0;
-        cache.consecutiveRateLimitCount = 0;
-        await writeCache(cache, cachePath);
-        await logger.log({ event: 'refresh.completed', outcome: 'success' });
+        const persisted = await persistSuccess(
+          startingCredentials,
+          startedAt,
+          cachePath,
+          usageResult,
+          now,
+          candidate,
+        );
+        await logger.log({
+          event: 'refresh.completed',
+          outcome: persisted ? 'success' : 'stale-discarded',
+        });
         return 0;
       }
     }
-  } catch (err: unknown) {
-    // Catastrophic uncaught error — swallow and exit 0 to be spawn-friendly.
-    // This path is a last resort; the code above should handle all known cases.
-    void err;
+  } catch {
     await logger.log({ event: 'refresh.crashed' });
     return 0;
   }
-
-  return 0;
 }

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -61,7 +61,13 @@ function formatRateLimitedHint(msUntilReset: number): string {
  * Low-level spawn abstraction: mirrors the child_process.spawn signature for
  * the pieces we care about, so tests can capture exactly what would be executed.
  */
-export type SpawnFn = (command: string, args: string[], opts: SpawnOptions) => void;
+type SafeSpawnOptions = SpawnOptions & { shell: false };
+
+export type SpawnFn = (
+  command: string,
+  args: string[],
+  opts: SafeSpawnOptions,
+) => void;
 
 export interface RenderEnterpriseDeps {
   cachePath?: string;
@@ -69,7 +75,6 @@ export interface RenderEnterpriseDeps {
   /** Override the spawn call for testing. Receives (command, args, opts). */
   spawnRefresh?: SpawnFn;
   now?: () => number;
-  platformOverride?: NodeJS.Platform;
 }
 
 // ---------------------------------------------------------------------------
@@ -254,12 +259,14 @@ function buildMinimalEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-function defaultSpawnFn(platform: NodeJS.Platform): SpawnFn {
-  return (command: string, args: string[], opts: SpawnOptions): void => {
-    const child = spawn(command, args, { ...opts, env: buildMinimalEnv(), shell: false });
-    if (platform !== 'win32') {
-      child.unref();
-    }
+function defaultSpawnFn(): SpawnFn {
+  return (command: string, args: string[], opts: SafeSpawnOptions): void => {
+    const child = spawn(command, args, {
+      ...opts,
+      env: buildMinimalEnv(),
+      shell: false,
+    });
+    child.unref();
   };
 }
 
@@ -408,9 +415,8 @@ export async function runRenderEnterprise(
   const cachePath = deps.cachePath ?? defaultCachePath();
   const bundlePath = deps.bundlePath ?? __filename;
   const now = deps.now ?? (() => Date.now());
-  const platform = deps.platformOverride ?? process.platform;
   const staleThresholdMs = getStaleThresholdMs();
-  const spawnFn = deps.spawnRefresh ?? defaultSpawnFn(platform);
+  const spawnFn = deps.spawnRefresh ?? defaultSpawnFn();
 
   // Step 1: Read stdin.
   const raw = await readStream(stdinSource);
@@ -448,31 +454,13 @@ export async function runRenderEnterprise(
       const minimalEnv = buildMinimalEnv();
       const claimArg = `--claimed-at=${claimedAt}`;
       try {
-        if (platform === 'win32') {
-          spawnFn(
-            'cmd.exe',
-            [
-              '/c',
-              'start',
-              '/b',
-              '/min',
-              process.execPath,
-              bundlePath,
-              'refresh',
-              claimArg,
-            ],
-            {
-              stdio: 'ignore',
-              env: minimalEnv,
-            },
-          );
-        } else {
-          spawnFn(process.execPath, [bundlePath, 'refresh', claimArg], {
-            detached: true,
-            stdio: 'ignore',
-            env: minimalEnv,
-          });
-        }
+        spawnFn(process.execPath, [bundlePath, 'refresh', claimArg], {
+          detached: true,
+          stdio: 'ignore',
+          windowsHide: true,
+          env: minimalEnv,
+          shell: false,
+        });
       } catch {
         await releaseRefreshClaim(cachePath, claimedAt);
       }

--- a/src/subcommands/render-enterprise.ts
+++ b/src/subcommands/render-enterprise.ts
@@ -14,16 +14,15 @@ import {
 } from '../statusline/format';
 import {
   readCache,
-  isRefreshInFlight,
+  updateCache,
   defaultCachePath,
 } from '../cache/store';
 import type { Cache } from '../cache/store';
 import type { ExtraUsage, UsageBucket, UsageResponse } from '../oauth/types';
 import {
-  createDiagnosticLogger,
-  defaultDiagnosticLogPath,
-  type DiagnosticLogger,
-} from '../diagnostics/logger';
+  decideEnterpriseRefresh,
+  rateLimitCooldownRemainingMs,
+} from './enterprise-refresh-policy';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -35,7 +34,9 @@ const STALE_THRESHOLD_MAX_MS = 300 * 1000; // 5 minutes
 const STALE_THRESHOLD_ENV = 'CC_STATUSLINE_ENTERPRISE_STALE_MS';
 
 /** Remediation hint appended when authState is 'fatal'. Must be ≤ 50 chars. */
-export const AUTH_FATAL_HINT = ' re-run init to re-auth';
+export const AUTH_FATAL_HINT = ' run init to repair auth';
+
+export const MISSING_CACHE_HINT = 'run init';
 
 /** Hint appended when authState is 'cloudflare-blocked'. */
 export const CLOUDFLARE_HINT = ' refresh blocked (cloudflare); see README#cloudflare';
@@ -65,10 +66,10 @@ export type SpawnFn = (command: string, args: string[], opts: SpawnOptions) => v
 export interface RenderEnterpriseDeps {
   cachePath?: string;
   bundlePath?: string;
-  logger?: DiagnosticLogger;
   /** Override the spawn call for testing. Receives (command, args, opts). */
   spawnRefresh?: SpawnFn;
   now?: () => number;
+  platformOverride?: NodeJS.Platform;
 }
 
 // ---------------------------------------------------------------------------
@@ -173,13 +174,6 @@ function getStaleThresholdMs(): number {
   return Math.max(STALE_THRESHOLD_MIN_MS, Math.min(STALE_THRESHOLD_MAX_MS, rounded));
 }
 
-function getCooldownRemainingMs(cache: Cache, nowMs: number): number {
-  return Math.max(
-    0,
-    Math.max(cache.rateLimitedUntilMs, cache.nextRefreshAllowedAt) - nowMs,
-  );
-}
-
 function buildExtraUsageSegment(extra: ExtraUsage): string {
   if (!hasCreditUsage(extra)) {
     return `usage ${MISSING}`;
@@ -206,7 +200,7 @@ function buildFallbackUsageSegment(usage: UsageResponse, nowMs: number): string 
 /**
  * Build the usage segment for Enterprise users.
  *
- * When cache is null (missing / malformed), returns `usage — · fetching…`.
+ * When cache is null (missing / malformed), returns an actionable init hint.
  * Staleness dim and STALE_MARKER are applied here.
  * Auth-state dim (fatal) is applied by the caller.
  */
@@ -216,7 +210,14 @@ function buildUsageSegment(
   nowMs: number,
   sessionCostUsd: number,
 ): { text: string; isFetching: boolean } {
-  if (cache === null || cache.usage === null) {
+  if (cache === null) {
+    return {
+      text: `usage ${MISSING}${SEP}${MISSING_CACHE_HINT}`,
+      isFetching: false,
+    };
+  }
+
+  if (cache.usage === null) {
     return { text: `usage ${MISSING}${SEP}fetching…`, isFetching: true };
   }
 
@@ -253,13 +254,68 @@ function buildMinimalEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-function defaultSpawnFn(): SpawnFn {
+function defaultSpawnFn(platform: NodeJS.Platform): SpawnFn {
   return (command: string, args: string[], opts: SpawnOptions): void => {
     const child = spawn(command, args, { ...opts, env: buildMinimalEnv(), shell: false });
-    if (process.platform !== 'win32') {
+    if (platform !== 'win32') {
       child.unref();
     }
   };
+}
+
+async function claimRefresh(
+  cachePath: string,
+  nowMs: number,
+  staleThresholdMs: number,
+): Promise<number | null> {
+  try {
+    return await updateCache(cachePath, (current) => {
+      const decision = decideEnterpriseRefresh(
+        current,
+        nowMs,
+        staleThresholdMs,
+      );
+      if (decision.action !== 'spawn' || current === null) {
+        return { kind: 'skip', value: null };
+      }
+      return {
+        kind: 'write',
+        cache: {
+          ...current,
+          lastRefreshStartedAt: nowMs,
+        },
+        value: nowMs,
+      };
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function releaseRefreshClaim(
+  cachePath: string,
+  claimedAt: number,
+): Promise<void> {
+  try {
+    await updateCache(cachePath, (current) => {
+      if (
+        current === null ||
+        current.lastRefreshStartedAt !== claimedAt
+      ) {
+        return { kind: 'skip', value: undefined };
+      }
+      return {
+        kind: 'write',
+        cache: {
+          ...current,
+          lastRefreshStartedAt: 0,
+        },
+        value: undefined,
+      };
+    });
+  } catch {
+    return;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +361,7 @@ function renderLine(
       // Render normally; just append hint.
       authHint = CLOUDFLARE_HINT;
     } else {
-      const cooldownRemainingMs = getCooldownRemainingMs(cache, nowMs);
+      const cooldownRemainingMs = rateLimitCooldownRemainingMs(cache, nowMs);
       if (cooldownRemainingMs > 0) {
         // Currently rate-limited (cooldown not yet elapsed). Render figures
         // normally — they're still the most recent we know — but tell the user
@@ -352,9 +408,9 @@ export async function runRenderEnterprise(
   const cachePath = deps.cachePath ?? defaultCachePath();
   const bundlePath = deps.bundlePath ?? __filename;
   const now = deps.now ?? (() => Date.now());
+  const platform = deps.platformOverride ?? process.platform;
   const staleThresholdMs = getStaleThresholdMs();
-  const logger = deps.logger ?? createDiagnosticLogger(defaultDiagnosticLogPath(cachePath), { now });
-  const spawnFn = deps.spawnRefresh ?? defaultSpawnFn();
+  const spawnFn = deps.spawnRefresh ?? defaultSpawnFn(platform);
 
   // Step 1: Read stdin.
   const raw = await readStream(stdinSource);
@@ -376,61 +432,50 @@ export async function runRenderEnterprise(
   // Step 2: Read cache synchronously.
   const cache = readCache(cachePath);
   const nowMs = now();
-  const refreshCooldownRemainingMs = cache !== null ? getCooldownRemainingMs(cache, nowMs) : 0;
-  const inCooldown = refreshCooldownRemainingMs > 0;
-  const inAdaptiveCooldown = cache !== null && cache.nextRefreshAllowedAt > cache.rateLimitedUntilMs;
+  const refreshDecision = decideEnterpriseRefresh(
+    cache,
+    nowMs,
+    staleThresholdMs,
+  );
 
-  // Step 3: Decide whether to fire a refresh subprocess.
-  const staleAge = cache !== null ? nowMs - cache.lastUsageRefreshAt : Infinity;
-  const isStale = staleAge >= staleThresholdMs;
-  const cacheIsMissing = cache === null;
-
-  // Don't fire if authState is 'fatal' (init must rerun).
-  const authFatal = cache?.authState === 'fatal';
-
-  // Don't fire if another refresh is already in flight.
-  const inFlight = cache !== null && isRefreshInFlight(cache, nowMs);
-
-  // Don't fire while in rate-limit cooldown — would just earn another 429.
-  // Includes adaptive backoff from previous rate-limit events.
-  // `inAdaptiveCooldown` tracks if adaptive backoff is stricter than upstream.
-
-  const shouldFire = (cacheIsMissing || isStale) && !authFatal && !inFlight && !inCooldown;
-
-  if (cacheIsMissing || isStale) {
-    const reason = cacheIsMissing
-      ? 'cache-missing'
-      : authFatal
-        ? 'auth-fatal'
-        : inFlight
-          ? 'in-flight'
-          : inCooldown
-            ? (inAdaptiveCooldown ? 'adaptive-backoff' : 'rate-limit-cooldown')
-            : 'stale-cache';
-    void logger.log({
-      event: 'render.refresh_decision',
-      action: shouldFire ? 'spawn' : 'skip',
-      reason,
-      usageAgeMs: Number.isFinite(staleAge) ? staleAge : null,
-      cooldownRemainingMs: inCooldown && cache !== null
-        ? refreshCooldownRemainingMs
-        : 0,
-    });
-  }
-
-  if (shouldFire) {
-    const minimalEnv = buildMinimalEnv();
-    if (process.platform === 'win32') {
-      spawnFn('cmd.exe', ['/c', 'start', '/b', '/min', process.execPath, bundlePath, 'refresh'], {
-        stdio: 'ignore',
-        env: minimalEnv,
-      });
-    } else {
-      spawnFn(process.execPath, [bundlePath, 'refresh'], {
-        detached: true,
-        stdio: 'ignore',
-        env: minimalEnv,
-      });
+  if (refreshDecision.action === 'spawn') {
+    const claimedAt = await claimRefresh(
+      cachePath,
+      nowMs,
+      staleThresholdMs,
+    );
+    if (claimedAt !== null) {
+      const minimalEnv = buildMinimalEnv();
+      const claimArg = `--claimed-at=${claimedAt}`;
+      try {
+        if (platform === 'win32') {
+          spawnFn(
+            'cmd.exe',
+            [
+              '/c',
+              'start',
+              '/b',
+              '/min',
+              process.execPath,
+              bundlePath,
+              'refresh',
+              claimArg,
+            ],
+            {
+              stdio: 'ignore',
+              env: minimalEnv,
+            },
+          );
+        } else {
+          spawnFn(process.execPath, [bundlePath, 'refresh', claimArg], {
+            detached: true,
+            stdio: 'ignore',
+            env: minimalEnv,
+          });
+        }
+      } catch {
+        await releaseRefreshClaim(cachePath, claimedAt);
+      }
     }
   }
 

--- a/tests/build-smoke.test.ts
+++ b/tests/build-smoke.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
 const BUNDLE = resolve(__dirname, '..', 'dist', 'cli.cjs');
+const CLI_SOURCE = resolve(__dirname, '..', 'src', 'cli.ts');
 
 describe('build smoke', () => {
   beforeAll(() => {
@@ -47,6 +48,19 @@ describe('build smoke', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Usage:');
     expect(result.stdout).toContain('Pro and Max use the same renderer');
+    expect(result.stdout.match(/--non-interactive/g)).toHaveLength(2);
+    expect(result.stdout).toContain('background credential + usage refresh');
+    expect(result.stdout).not.toContain('background token + usage refresh');
+  });
+
+  it('source help documents non-interactive init and background credential refresh', () => {
+    const source = readFileSync(CLI_SOURCE, 'utf8');
+    const help = source.match(/const HELP = `([\s\S]*?)`;/)?.[1];
+
+    expect(help).toBeDefined();
+    expect(help?.match(/--non-interactive/g)).toHaveLength(2);
+    expect(help).toContain('background credential + usage refresh');
+    expect(help).not.toContain('background token + usage refresh');
   });
 
   it('prints the package version on --version', () => {

--- a/tests/cache-lock.test.ts
+++ b/tests/cache-lock.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const uuidSequence = vi.hoisted(() => ({
+  values: [] as string[],
+}));
+
+vi.mock('node:crypto', () => ({
+  randomUUID: () => uuidSequence.values.shift(),
+}));
+
+import { withCacheLock } from '../src/cache/lock';
+
+beforeEach(() => {
+  uuidSequence.values = [
+    'ffffffff-ffff-4fff-8fff-ffffffffffff',
+    '00000000-0000-4000-8000-000000000000',
+  ];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('withCacheLock', () => {
+  it('does not let a same-millisecond contender preempt the active owner', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    const tempDir = mkdtempSync(join(tmpdir(), 'cc-statusline-lock-order-'));
+    const cachePath = join(tempDir, 'cache.json');
+    let releaseFirst: (() => void) | undefined;
+    let secondEntered = false;
+
+    const first = withCacheLock(cachePath, async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+    });
+
+    while (releaseFirst === undefined) {
+      await delay(1);
+    }
+
+    const second = withCacheLock(cachePath, async () => {
+      secondEntered = true;
+    });
+
+    try {
+      await delay(30);
+      expect(secondEntered).toBe(false);
+    } finally {
+      releaseFirst();
+      await Promise.allSettled([first, second]);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    expect(secondEntered).toBe(true);
+  });
+});

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -5,22 +5,23 @@ import * as os from 'os';
 import {
   readCache,
   writeCache,
+  updateCache,
   isRefreshInFlight,
   sanitizeErrorMessage,
   defaultCachePath,
   type Cache,
 } from '../src/cache/store';
-import type { OAuthCredentials } from '../src/oauth/types';
+import type { OAuthCredentials } from '../src/credentials/envelope';
 
 function makeMinimalCache(overrides: Partial<Cache> = {}): Cache {
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     authState: 'ok',
     credentials: {
       accessToken: 'sk-ant-access',
-      refreshToken: 'rt-refresh',
       expiresAt: Date.now() + 3_600_000,
     },
+    credentialSource: { kind: 'claude-code' },
     usage: null,
     lastUsageRefreshAt: 0,
     lastRefreshStartedAt: 0,
@@ -30,6 +31,17 @@ function makeMinimalCache(overrides: Partial<Cache> = {}): Cache {
     consecutiveRateLimitCount: 0,
     ...overrides,
   };
+}
+
+function readJsonCache(value: unknown): Cache | null {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-read-cache-'));
+  const tmpFile = path.join(tmpDir, 'cache.json');
+  fs.writeFileSync(tmpFile, JSON.stringify(value), 'utf8');
+  try {
+    return readCache(tmpFile);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 }
 
 describe('defaultCachePath', () => {
@@ -91,25 +103,171 @@ describe('readCache', () => {
     }
   });
 
-  it('returns a typed Cache object for valid v3 JSON', () => {
-    const cache = makeMinimalCache();
-    const tmpFile = path.join(os.tmpdir(), `cc-statusline-test-${Date.now()}.json`);
+  it('returns a valid v4 cache with source provenance and access-only credentials', () => {
+    const cache = {
+      schemaVersion: 4,
+      authState: 'ok',
+      credentials: {
+        accessToken: 'sk-ant-access',
+        expiresAt: Date.now() + 3_600_000,
+      },
+      credentialSource: { kind: 'claude-code' },
+      usage: null,
+      lastUsageRefreshAt: 0,
+      lastRefreshStartedAt: 0,
+      lastErrorMessage: null,
+      rateLimitedUntilMs: 0,
+      nextRefreshAllowedAt: 0,
+      consecutiveRateLimitCount: 0,
+    };
+    const tmpFile = path.join(os.tmpdir(), `cc-statusline-v4-${Date.now()}.json`);
     fs.writeFileSync(tmpFile, JSON.stringify(cache, null, 2) + '\n', 'utf8');
     try {
-      const result = readCache(tmpFile);
-      expect(result).not.toBeNull();
-      expect(result?.schemaVersion).toBe(3);
-      expect(result?.authState).toBe('ok');
-      expect(result?.credentials.accessToken).toBe('sk-ant-access');
-      expect(result?.rateLimitedUntilMs).toBe(0);
-      expect(result?.nextRefreshAllowedAt).toBe(0);
-      expect(result?.consecutiveRateLimitCount).toBe(0);
+      expect(readCache(tmpFile)).toEqual(cache);
     } finally {
       fs.unlinkSync(tmpFile);
     }
   });
 
-  it('migrates a v1 cache to v3 with backoff defaults', () => {
+  it('accepts each auth state and an explicit file source without filesystem validation', () => {
+    const sourcePath = path.join(
+      os.homedir(),
+      'cc-statusline-source-does-not-need-to-exist.json',
+    );
+
+    for (const authState of ['ok', 'fatal', 'cloudflare-blocked'] as const) {
+      const cache = makeMinimalCache({
+        authState,
+        credentialSource: { kind: 'file', path: sourcePath },
+      });
+      expect(readJsonCache(cache)).toEqual(cache);
+    }
+  });
+
+  it.each([
+    ['an array at the top level', []],
+    ['missing required fields', { schemaVersion: 4 }],
+    ['an invalid auth state', { ...makeMinimalCache(), authState: 'unknown' }],
+    ['non-object credentials', { ...makeMinimalCache(), credentials: [] }],
+    [
+      'an empty access token',
+      {
+        ...makeMinimalCache(),
+        credentials: { accessToken: '', expiresAt: Date.now() },
+      },
+    ],
+    [
+      'a non-numeric credential expiry',
+      {
+        ...makeMinimalCache(),
+        credentials: { accessToken: 'access', expiresAt: 'later' },
+      },
+    ],
+    [
+      'a refresh token',
+      {
+        ...makeMinimalCache(),
+        credentials: {
+          accessToken: 'access',
+          expiresAt: Date.now(),
+          refreshToken: 'must-not-be-cached',
+        },
+      },
+    ],
+    [
+      'an invalid credential source kind',
+      { ...makeMinimalCache(), credentialSource: { kind: 'environment' } },
+    ],
+    [
+      'an empty explicit credential path',
+      { ...makeMinimalCache(), credentialSource: { kind: 'file', path: '' } },
+    ],
+    ['an array usage value', { ...makeMinimalCache(), usage: [] }],
+    ['a primitive usage value', { ...makeMinimalCache(), usage: 'unknown' }],
+    [
+      'an invalid usage bucket',
+      {
+        ...makeMinimalCache(),
+        usage: { five_hour: { utilization: 'unknown' } },
+      },
+    ],
+    [
+      'an invalid extra usage value',
+      {
+        ...makeMinimalCache(),
+        usage: { extra_usage: { is_enabled: 'yes' } },
+      },
+    ],
+    [
+      'a non-numeric last usage refresh',
+      { ...makeMinimalCache(), lastUsageRefreshAt: 'never' },
+    ],
+    [
+      'a non-numeric last refresh start',
+      { ...makeMinimalCache(), lastRefreshStartedAt: 'never' },
+    ],
+    [
+      'a non-numeric rate-limit deadline',
+      { ...makeMinimalCache(), rateLimitedUntilMs: 'never' },
+    ],
+    [
+      'a non-numeric adaptive-backoff deadline',
+      { ...makeMinimalCache(), nextRefreshAllowedAt: 'never' },
+    ],
+    [
+      'a negative consecutive rate-limit count',
+      { ...makeMinimalCache(), consecutiveRateLimitCount: -1 },
+    ],
+    [
+      'a fractional consecutive rate-limit count',
+      { ...makeMinimalCache(), consecutiveRateLimitCount: 1.5 },
+    ],
+    [
+      'a non-string last error',
+      { ...makeMinimalCache(), lastErrorMessage: { message: 'failed' } },
+    ],
+  ])('returns null for a v4 cache with %s', (_description, cache) => {
+    expect(readJsonCache(cache)).toBeNull();
+  });
+
+  it('returns null for non-finite numeric fields parsed from valid JSON', () => {
+    const cache = makeMinimalCache();
+    const content = JSON.stringify(cache)
+      .replace(
+        `"expiresAt":${cache.credentials.expiresAt}`,
+        '"expiresAt":1e400',
+      )
+      .replace('"lastUsageRefreshAt":0', '"lastUsageRefreshAt":1e400');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-read-cache-'));
+    const tmpFile = path.join(tmpDir, 'cache.json');
+    fs.writeFileSync(tmpFile, content, 'utf8');
+    try {
+      expect(readCache(tmpFile)).toBeNull();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for a v3 cache', () => {
+    const cache = {
+      ...makeMinimalCache(),
+      schemaVersion: 3,
+      credentials: {
+        accessToken: 'sk-ant-access',
+        refreshToken: 'rt-refresh',
+        expiresAt: Date.now() + 3_600_000,
+      },
+    };
+    const tmpFile = path.join(os.tmpdir(), `cc-statusline-test-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(cache, null, 2) + '\n', 'utf8');
+    try {
+      expect(readCache(tmpFile)).toBeNull();
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('returns null for a v1 cache', () => {
     const v1Cache = {
       schemaVersion: 1,
       authState: 'ok',
@@ -126,21 +284,13 @@ describe('readCache', () => {
     const tmpFile = path.join(os.tmpdir(), `cc-statusline-v1-${Date.now()}.json`);
     fs.writeFileSync(tmpFile, JSON.stringify(v1Cache, null, 2) + '\n', 'utf8');
     try {
-      const result = readCache(tmpFile);
-      expect(result).not.toBeNull();
-      expect(result?.schemaVersion).toBe(3);
-      expect(result?.rateLimitedUntilMs).toBe(0);
-      expect(result?.nextRefreshAllowedAt).toBe(0);
-      expect(result?.consecutiveRateLimitCount).toBe(0);
-      // Other fields preserved
-      expect(result?.credentials.accessToken).toBe('v1-access');
-      expect(result?.lastUsageRefreshAt).toBe(12345);
+      expect(readCache(tmpFile)).toBeNull();
     } finally {
       fs.unlinkSync(tmpFile);
     }
   });
 
-  it('migrates a v2 cache to v3 with backoff defaults', () => {
+  it('returns null for a v2 cache', () => {
     const rateLimitedUntilMs = Date.now() + 90_000;
     const v2Cache = {
       schemaVersion: 2,
@@ -159,12 +309,7 @@ describe('readCache', () => {
     const tmpFile = path.join(os.tmpdir(), `cc-statusline-v2-${Date.now()}.json`);
     fs.writeFileSync(tmpFile, JSON.stringify(v2Cache, null, 2) + '\n', 'utf8');
     try {
-      const result = readCache(tmpFile);
-      expect(result).not.toBeNull();
-      expect(result?.schemaVersion).toBe(3);
-      expect(result?.rateLimitedUntilMs).toBe(rateLimitedUntilMs);
-      expect(result?.nextRefreshAllowedAt).toBe(0);
-      expect(result?.consecutiveRateLimitCount).toBe(0);
+      expect(readCache(tmpFile)).toBeNull();
     } finally {
       fs.unlinkSync(tmpFile);
     }
@@ -183,7 +328,7 @@ describe('writeCache', () => {
 
       const content = fs.readFileSync(filePath, 'utf8');
       const parsed = JSON.parse(content);
-      expect(parsed.schemaVersion).toBe(3);
+      expect(parsed.schemaVersion).toBe(4);
       expect(content.endsWith('\n')).toBe(true);
     } finally {
       fs.rmSync(tmpBase, { recursive: true, force: true });
@@ -209,26 +354,141 @@ describe('writeCache', () => {
     }
   });
 
+  it('never persists a refresh token from candidate credentials', async () => {
+    const tmpBase = path.join(os.tmpdir(), `cc-statusline-secrets-${Date.now()}`);
+    const filePath = path.join(tmpBase, 'cache.json');
+    const cache = makeMinimalCache();
+    const credentialsWithRefreshToken = {
+      ...cache.credentials,
+      refreshToken: 'rt-must-not-be-cached',
+    };
+
+    try {
+      await writeCache({ ...cache, credentials: credentialsWithRefreshToken }, filePath);
+      const content = fs.readFileSync(filePath, 'utf8');
+      expect(JSON.parse(content).credentials).toEqual({
+        accessToken: 'sk-ant-access',
+        expiresAt: cache.credentials.expiresAt,
+      });
+      expect(content).not.toContain('rt-must-not-be-cached');
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+});
+
+describe('updateCache', () => {
+  it('serializes read-modify-write transactions without losing either update', async () => {
+    const tmpBase = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'cc-statusline-update-cache-'),
+    );
+    const filePath = path.join(tmpBase, 'cache.json');
+    await writeCache(makeMinimalCache(), filePath);
+
+    try {
+      await Promise.all([
+        updateCache(filePath, (current) => {
+          if (current === null) throw new Error('cache unexpectedly missing');
+          return {
+            kind: 'write',
+            cache: {
+              ...current,
+              lastErrorMessage: 'first update',
+            },
+            value: undefined,
+          };
+        }),
+        updateCache(filePath, (current) => {
+          if (current === null) throw new Error('cache unexpectedly missing');
+          return {
+            kind: 'write',
+            cache: {
+              ...current,
+              authState: 'fatal',
+            },
+            value: undefined,
+          };
+        }),
+      ]);
+
+      expect(readCache(filePath)).toMatchObject({
+        authState: 'fatal',
+        lastErrorMessage: 'first update',
+      });
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a dead contender without deleting a live successor', async () => {
+    const tmpBase = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'cc-statusline-stale-lock-'),
+    );
+    const filePath = path.join(tmpBase, 'cache.json');
+    const lockDir = `${filePath}.locks`;
+    fs.mkdirSync(lockDir, { mode: 0o700 });
+    fs.writeFileSync(
+      path.join(lockDir, 'stale.ticket'),
+      JSON.stringify({
+        pid: 2_147_483_647,
+        createdAt: Date.now() - 180_000,
+        token: 'stale',
+        ticket: 1,
+      }),
+      { mode: 0o600 },
+    );
+    await writeCache(makeMinimalCache(), filePath);
+
+    try {
+      await Promise.all([
+        updateCache(filePath, (current) => {
+          if (current === null) throw new Error('cache unexpectedly missing');
+          return {
+            kind: 'write',
+            cache: { ...current, lastErrorMessage: 'first' },
+            value: undefined,
+          };
+        }),
+        updateCache(filePath, (current) => {
+          if (current === null) throw new Error('cache unexpectedly missing');
+          return {
+            kind: 'write',
+            cache: { ...current, authState: 'fatal' },
+            value: undefined,
+          };
+        }),
+      ]);
+
+      expect(readCache(filePath)).toMatchObject({
+        authState: 'fatal',
+        lastErrorMessage: 'first',
+      });
+      expect(
+        fs.existsSync(lockDir) ? fs.readdirSync(lockDir) : [],
+      ).toEqual([]);
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('isRefreshInFlight', () => {
-  it('returns true when lastRefreshStartedAt is 500ms ago', () => {
+  it('returns true while a normal auth recovery can still be running', () => {
     const now = Date.now();
-    const cache = makeMinimalCache({ lastRefreshStartedAt: now - 500 });
+    const cache = makeMinimalCache({ lastRefreshStartedAt: now - 30_000 });
     expect(isRefreshInFlight(cache, now)).toBe(true);
   });
 
-  it('returns false when lastRefreshStartedAt is 1500ms ago', () => {
+  it('returns false after the refresh lease expires', () => {
     const now = Date.now();
-    const cache = makeMinimalCache({ lastRefreshStartedAt: now - 1500 });
+    const cache = makeMinimalCache({ lastRefreshStartedAt: now - 45_001 });
     expect(isRefreshInFlight(cache, now)).toBe(false);
   });
 
   it('returns false when lastRefreshStartedAt is 0 (never started)', () => {
-    const now = Date.now();
     const cache = makeMinimalCache({ lastRefreshStartedAt: 0 });
-    // 0 means never; now - 0 is a large number >> 1000
-    expect(isRefreshInFlight(cache, now)).toBe(false);
+    expect(isRefreshInFlight(cache, 0)).toBe(false);
   });
 });
 
@@ -256,6 +516,22 @@ describe('sanitizeErrorMessage', () => {
     expect(result).toBe('access=<redacted> refresh=<redacted>');
     expect(result).not.toContain('sk-ant-abc123');
     expect(result).not.toContain('rt-xyz');
+  });
+
+  it('redacts a cached access token and tokens from an optional full candidate', () => {
+    const result = sanitizeErrorMessage(
+      'cached=old-access candidate=new-access refresh=new-refresh',
+      { accessToken: 'old-access', expiresAt: 0 },
+      {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: 0,
+      },
+    );
+
+    expect(result).toBe(
+      'cached=<redacted> candidate=<redacted> refresh=<redacted>',
+    );
   });
 
   it('does not mutate the message when token is empty string', () => {

--- a/tests/credentials-discover.test.ts
+++ b/tests/credentials-discover.test.ts
@@ -325,6 +325,24 @@ describe('discover', () => {
     expect(spawnFn).not.toHaveBeenCalled();
   });
 
+  it('uses an injected Claude config directory for automatic file discovery', async () => {
+    const configDir = join(HOME, 'custom-claude');
+    const configuredCredentialsPath = join(configDir, '.credentials.json');
+    const readFileFn = makeFakeReadFile({
+      [configuredCredentialsPath]: envelopeJson(VALID_ENVELOPE),
+    });
+
+    const result = await discover({
+      platformOverride: 'linux',
+      homedirOverride: HOME,
+      claudeConfigDirOverride: configDir,
+      readFileOverride: readFileFn,
+    });
+
+    expect(result).toEqual(VALID_ENVELOPE.claudeAiOauth);
+    expect(readFileFn).toHaveBeenCalledWith(configuredCredentialsPath, 'utf-8');
+  });
+
   it('happy Windows file: returns credentials from .credentials.json without calling spawn', async () => {
     const spawnFn = makeFakeSpawn('', 0);
     const readFileFn = makeFakeReadFile({
@@ -484,6 +502,22 @@ describe('discover', () => {
         readFileOverride: readFileFn,
       }),
     ).rejects.toThrow(/invalid JSON/i);
+  });
+
+  it('invalid JSON errors never reflect credential file contents', async () => {
+    const leakedToken = 'sk-ant-must-not-appear';
+    const readFileFn = makeFakeReadFile({
+      [dotCredPath]: `{"claudeAiOauth": {"accessToken": "${leakedToken}"`,
+    });
+
+    const rejection = discover({
+      platformOverride: 'linux',
+      homedirOverride: HOME,
+      readFileOverride: readFileFn,
+    });
+
+    await expect(rejection).rejects.toThrow(/invalid JSON/i);
+    await expect(rejection).rejects.not.toThrow(leakedToken);
   });
 
   // ── EACCES ─────────────────────────────────────────────────────────────

--- a/tests/credentials-source.test.ts
+++ b/tests/credentials-source.test.ts
@@ -57,7 +57,7 @@ describe('loadCredentialSource', () => {
 
       expect(source).toEqual({
         kind: 'file',
-        path: fs.realpathSync(credentialsPath),
+        path: await fs.promises.realpath(credentialsPath),
       });
       expect(credentials).toEqual({
         accessToken: 'file-access',

--- a/tests/credentials-source.test.ts
+++ b/tests/credentials-source.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  canonicalizeFileCredentialSource,
+  loadCredentialSource,
+} from '../src/credentials/source';
+
+function envelope(accessToken: string, refreshToken: string): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken,
+      refreshToken,
+      expiresAt: 9_999_999_999_000,
+    },
+  });
+}
+
+describe('loadCredentialSource', () => {
+  it('rediscovers Claude Code credentials on every load', async () => {
+    const values = [
+      envelope('access-one', 'refresh-one'),
+      envelope('access-two', 'refresh-two'),
+    ];
+    const readFileOverride = vi.fn(async () => values.shift()!);
+    const options = {
+      platformOverride: 'linux' as const,
+      homedirOverride: '/fake/home',
+      claudeConfigDirOverride: '/fake/config',
+      readFileOverride:
+        readFileOverride as unknown as typeof import('node:fs/promises').readFile,
+    };
+
+    const first = await loadCredentialSource({ kind: 'claude-code' }, options);
+    const second = await loadCredentialSource({ kind: 'claude-code' }, options);
+
+    expect(first.accessToken).toBe('access-one');
+    expect(second.accessToken).toBe('access-two');
+    expect(readFileOverride).toHaveBeenCalledTimes(2);
+  });
+
+  it('canonicalizes an in-home regular file and loads its credentials', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-source-'));
+    const home = path.join(tmpDir, 'home');
+    const credentialsPath = path.join(home, 'credentials.json');
+    fs.mkdirSync(home);
+    fs.writeFileSync(credentialsPath, envelope('file-access', 'file-refresh'));
+
+    try {
+      const source = await canonicalizeFileCredentialSource(credentialsPath, {
+        homedirOverride: home,
+      });
+      const credentials = await loadCredentialSource(source, {
+        homedirOverride: home,
+      });
+
+      expect(source).toEqual({
+        kind: 'file',
+        path: fs.realpathSync(credentialsPath),
+      });
+      expect(credentials).toEqual({
+        accessToken: 'file-access',
+        refreshToken: 'file-refresh',
+        expiresAt: 9_999_999_999_000,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a file source that resolves outside home on a later load', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-source-'));
+    const home = path.join(tmpDir, 'home');
+    const credentialsPath = path.join(home, 'credentials.json');
+    const outsidePath = path.join(tmpDir, 'outside.json');
+    fs.mkdirSync(home);
+    fs.writeFileSync(credentialsPath, envelope('initial-access', 'initial-refresh'));
+    fs.writeFileSync(outsidePath, envelope('outside-access', 'outside-refresh'));
+
+    try {
+      const source = await canonicalizeFileCredentialSource(credentialsPath, {
+        homedirOverride: home,
+      });
+      fs.unlinkSync(credentialsPath);
+      fs.symlinkSync(outsidePath, credentialsPath);
+
+      await expect(
+        loadCredentialSource(source, { homedirOverride: home }),
+      ).rejects.toThrow(/outside home directory/i);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a file source that is no longer a regular file', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-source-'));
+    const home = path.join(tmpDir, 'home');
+    const credentialsPath = path.join(home, 'credentials.json');
+    fs.mkdirSync(home);
+    fs.writeFileSync(credentialsPath, envelope('initial-access', 'initial-refresh'));
+
+    try {
+      const source = await canonicalizeFileCredentialSource(credentialsPath, {
+        homedirOverride: home,
+      });
+      fs.unlinkSync(credentialsPath);
+      fs.mkdirSync(credentialsPath);
+
+      await expect(
+        loadCredentialSource(source, { homedirOverride: home }),
+      ).rejects.toThrow(/not a regular file/i);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -15,13 +15,13 @@ function cachePathOf(dir: string): string {
 
 function makeCache(overrides: Partial<Cache> = {}): Cache {
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     authState: 'ok',
     credentials: {
       accessToken: 'sk-ant-secret-do-not-leak',
-      refreshToken: 'rt-secret-do-not-leak',
       expiresAt: Date.now() + 3_600_000,
     },
+    credentialSource: { kind: 'claude-code' },
     usage: null,
     lastUsageRefreshAt: 0,
     lastRefreshStartedAt: 0,
@@ -65,7 +65,21 @@ describe('runDoctor', () => {
     expect(exitCode).toBe(0);
     const output = captured.join('');
     expect(output).toContain('absent');
-    expect(output).toContain('--plan');
+    expect(output).toContain('run init');
+  });
+
+  it('treats malformed v4 JSON as an absent cache', async () => {
+    const cachePath = cachePathOf(tmpDir);
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify({ schemaVersion: 4 }),
+      'utf8',
+    );
+
+    expect(await runDoctor([], { cachePath })).toBe(0);
+    const output = captured.join('');
+    expect(output).toContain('absent or unreadable');
+    expect(output).toContain('run init');
   });
 
   it('cache present: surfaces authState, last usage, rate-limit status', async () => {
@@ -87,8 +101,21 @@ describe('runDoctor', () => {
     expect(output).toContain('authState:     ok');
     expect(output).toContain('last usage:    30s ago');
     expect(output).toContain('rate limit:    not rate-limited');
-    expect(output).toContain('credential use: local cache (cache.json)');
-    expect(output).toContain('credential origin: not recorded');
+    expect(output).toContain('credential source: Claude Code');
+  });
+
+  it('reports an explicit-file source without exposing its path', async () => {
+    const sourcePath = path.join(tmpDir, 'secret', 'credentials.json');
+    const cache = makeCache({
+      credentialSource: { kind: 'file', path: sourcePath },
+    });
+    await writeCache(cache, cachePathOf(tmpDir));
+
+    await runDoctor([], { cachePath: cachePathOf(tmpDir) });
+    const output = captured.join('');
+
+    expect(output).toContain('credential source: explicit file');
+    expect(output).not.toContain(sourcePath);
   });
 
   it('cooldown active: shows cooldown remaining', async () => {
@@ -104,7 +131,7 @@ describe('runDoctor', () => {
     expect(output).toMatch(/in \d+m/);
   });
 
-  it('does NOT leak access or refresh token in output', async () => {
+  it('does NOT leak the access token in output', async () => {
     const now = Date.now();
     const cache = makeCache({
       lastErrorMessage: 'some error from earlier',
@@ -114,7 +141,6 @@ describe('runDoctor', () => {
     await runDoctor([], { cachePath: cachePathOf(tmpDir), now: () => now });
     const output = captured.join('');
     expect(output).not.toContain('sk-ant-secret-do-not-leak');
-    expect(output).not.toContain('rt-secret-do-not-leak');
   });
 
   it('surfaces lastErrorMessage when set', async () => {
@@ -159,6 +185,5 @@ describe('runDoctor', () => {
     expect(output).toContain('usage.response');
     expect(output).toContain('"status":429');
     expect(output).not.toContain('sk-ant-secret-do-not-leak');
-    expect(output).not.toContain('rt-secret-do-not-leak');
   });
 });

--- a/tests/enterprise-refresh-policy.test.ts
+++ b/tests/enterprise-refresh-policy.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decideEnterpriseRefresh,
+  refreshCooldownRemainingMs,
+} from '../src/subcommands/enterprise-refresh-policy';
+import { makeCache } from './support/render-enterprise';
+
+const NOW = Date.parse('2026-07-28T12:00:00Z');
+const STALE_AFTER_MS = 60_000;
+
+describe('decideEnterpriseRefresh', () => {
+  it('requires init when no cache exists', () => {
+    expect(
+      decideEnterpriseRefresh(null, NOW, STALE_AFTER_MS),
+    ).toEqual({
+      action: 'skip',
+      reason: 'cache-missing',
+      usageAgeMs: null,
+      cooldownRemainingMs: 0,
+    });
+  });
+
+  it('does nothing while normal credentials and usage are fresh', () => {
+    const cache = makeCache({
+      lastUsageRefreshAt: NOW - 30_000,
+    });
+
+    expect(
+      decideEnterpriseRefresh(cache, NOW, STALE_AFTER_MS),
+    ).toEqual({ action: 'none' });
+  });
+
+  it('spawns a refresh for stale usage', () => {
+    const cache = makeCache({
+      lastUsageRefreshAt: NOW - STALE_AFTER_MS,
+    });
+
+    expect(
+      decideEnterpriseRefresh(cache, NOW, STALE_AFTER_MS),
+    ).toEqual({
+      action: 'spawn',
+      reason: 'stale-cache',
+      usageAgeMs: STALE_AFTER_MS,
+      cooldownRemainingMs: 0,
+    });
+  });
+
+  it('does not duplicate an in-flight refresh', () => {
+    const cache = makeCache({
+      lastUsageRefreshAt: NOW - STALE_AFTER_MS,
+      lastRefreshStartedAt: NOW - 30_000,
+    });
+
+    expect(
+      decideEnterpriseRefresh(cache, NOW, STALE_AFTER_MS),
+    ).toMatchObject({
+      action: 'skip',
+      reason: 'in-flight',
+    });
+  });
+
+  it('honors upstream and adaptive cooldowns', () => {
+    const upstream = makeCache({
+      lastUsageRefreshAt: NOW - STALE_AFTER_MS,
+      rateLimitedUntilMs: NOW + 30_000,
+    });
+    const adaptive = makeCache({
+      lastUsageRefreshAt: NOW - STALE_AFTER_MS,
+      rateLimitedUntilMs: NOW - 1,
+      nextRefreshAllowedAt: NOW + 90_000,
+      consecutiveRateLimitCount: 1,
+    });
+
+    expect(
+      decideEnterpriseRefresh(upstream, NOW, STALE_AFTER_MS),
+    ).toMatchObject({
+      action: 'skip',
+      reason: 'rate-limit-cooldown',
+      cooldownRemainingMs: 30_000,
+    });
+    expect(
+      decideEnterpriseRefresh(adaptive, NOW, STALE_AFTER_MS),
+    ).toMatchObject({
+      action: 'skip',
+      reason: 'adaptive-backoff',
+      cooldownRemainingMs: 90_000,
+    });
+  });
+
+  it('honors a bounded retry cooldown after a non-rate-limit failure', () => {
+    const cache = makeCache({
+      lastUsageRefreshAt: NOW - STALE_AFTER_MS,
+      nextRefreshAllowedAt: NOW + 30_000,
+      consecutiveRateLimitCount: 0,
+    });
+
+    expect(
+      decideEnterpriseRefresh(cache, NOW, STALE_AFTER_MS),
+    ).toMatchObject({
+      action: 'skip',
+      reason: 'retry-cooldown',
+      cooldownRemainingMs: 30_000,
+    });
+  });
+
+  it('retries fatal authentication immediately, then every five minutes', () => {
+    const firstAttempt = makeCache({
+      authState: 'fatal',
+      lastUsageRefreshAt: NOW - 30_000,
+      lastRefreshStartedAt: 0,
+    });
+    const throttled = makeCache({
+      authState: 'fatal',
+      lastUsageRefreshAt: NOW - 30_000,
+      lastRefreshStartedAt: NOW - 2 * 60_000,
+    });
+    const retryEligible = makeCache({
+      authState: 'fatal',
+      lastUsageRefreshAt: NOW - 30_000,
+      lastRefreshStartedAt: NOW - 5 * 60_000,
+    });
+
+    expect(
+      decideEnterpriseRefresh(firstAttempt, NOW, STALE_AFTER_MS),
+    ).toMatchObject({
+      action: 'spawn',
+      reason: 'auth-fatal-retry',
+    });
+    expect(
+      decideEnterpriseRefresh(throttled, NOW, STALE_AFTER_MS),
+    ).toMatchObject({
+      action: 'skip',
+      reason: 'auth-fatal-throttled',
+    });
+    expect(
+      decideEnterpriseRefresh(retryEligible, NOW, STALE_AFTER_MS),
+    ).toMatchObject({
+      action: 'spawn',
+      reason: 'auth-fatal-retry',
+    });
+  });
+});
+
+describe('refreshCooldownRemainingMs', () => {
+  it('uses the stricter of upstream and adaptive deadlines', () => {
+    const cache = makeCache({
+      rateLimitedUntilMs: NOW + 30_000,
+      nextRefreshAllowedAt: NOW + 90_000,
+    });
+
+    expect(refreshCooldownRemainingMs(cache, NOW)).toBe(90_000);
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,33 +1,47 @@
-/**
- * Tests for src/subcommands/init.ts
- *
- * All file I/O uses temp dirs under os.tmpdir().
- * No real keychain access, no real ~/.claude/ is touched.
- * The test suite covers all 25 scenarios specified in U9.
- */
-
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { createHash } from 'node:crypto';
-import { runInit, type InitDeps } from '../src/subcommands/init';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  runInit,
+  type InitDeps,
+  type SpawnClaudeResult,
+} from '../src/subcommands/init';
 import { readCache, writeCache, type Cache } from '../src/cache/store';
+import { CredentialNotFoundError } from '../src/credentials/discover';
 import { readSettings } from '../src/settings/mutator';
-import type { OAuthCredentials, UsageResponse } from '../src/oauth/types';
+import type { OAuthCredentials } from '../src/credentials/envelope';
+import type { UsageResponse } from '../src/oauth/types';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const NOW = Date.parse('2026-07-28T12:00:00Z');
+
+const MOCK_CREDENTIALS: OAuthCredentials = {
+  accessToken: 'sk-ant-access-token',
+  refreshToken: 'rt-refresh-token',
+  expiresAt: NOW + 3_600_000,
+};
+
+const MOCK_USAGE: UsageResponse = {
+  five_hour: { utilization: 10, resets_at: '2026-07-28T17:00:00Z' },
+  seven_day: { utilization: 20, resets_at: '2026-08-04T00:00:00Z' },
+};
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function makeTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'cc-init-test-'));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-init-test-'));
+  tmpDirs.push(dir);
+  return dir;
 }
 
-// All paths mirror production layout under <homedir>/.claude/. The init impl
-// derives the install dir from homedirOverride; tests must look in the same
-// place. settings/cache paths are also overridden via InitDeps to put them
-// under .claude/ so re-reads via readSettings/readCache observe the same files.
 function settingsPath(dir: string): string {
   return path.join(dir, '.claude', 'settings.json');
 }
@@ -40,42 +54,46 @@ function bundlePath(dir: string): string {
   return path.join(dir, '.claude', 'cc-statusline', 'cc-statusline.js');
 }
 
-function writeJson(filePath: string, obj: unknown): void {
+function makeFakeBundle(dir: string, content = '#!/usr/bin/env node\n'): string {
+  const filePath = path.join(dir, 'fake-bundle.js');
+  fs.writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
+
+function writeJson(filePath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
 function fileHash(filePath: string): string {
-  const buf = fs.readFileSync(filePath);
-  return createHash('sha256').update(buf).digest('hex');
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
 }
 
-const MOCK_CREDENTIALS: OAuthCredentials = {
-  accessToken: 'sk-ant-access-token',
-  refreshToken: 'rt-refresh-token',
-  expiresAt: Date.now() + 3_600_000, // 1 hour from now
-};
+function makeFetch(status = 200): typeof fetch {
+  return vi.fn(async () => {
+    const body = status === 200 ? JSON.stringify(MOCK_USAGE) : undefined;
+    const headers = status === 429 ? { 'Retry-After': '12' } : undefined;
+    return new Response(body, { status, headers });
+  }) as unknown as typeof fetch;
+}
 
-const VALID_ENVELOPE = {
-  claudeAiOauth: {
-    accessToken: MOCK_CREDENTIALS.accessToken,
-    refreshToken: MOCK_CREDENTIALS.refreshToken,
-    expiresAt: MOCK_CREDENTIALS.expiresAt,
-  },
-};
+function makeThrowingFetch(message = 'timed out'): typeof fetch {
+  return vi.fn(async () => {
+    throw new Error(message);
+  }) as unknown as typeof fetch;
+}
 
-const MOCK_USAGE: UsageResponse = {
-  five_hour: { utilization: 0.1, resetsAt: '2026-05-03T12:00:00Z' },
-  seven_day: { utilization: 0.2, resetsAt: '2026-05-10T00:00:00Z' },
-};
-
-function makeValidCache(overrides: Partial<Cache> = {}): Cache {
+function makeCache(overrides: Partial<Cache> = {}): Cache {
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     authState: 'ok',
-    credentials: MOCK_CREDENTIALS,
+    credentials: {
+      accessToken: MOCK_CREDENTIALS.accessToken,
+      expiresAt: MOCK_CREDENTIALS.expiresAt,
+    },
+    credentialSource: { kind: 'claude-code' },
     usage: MOCK_USAGE,
-    lastUsageRefreshAt: Date.now(),
+    lastUsageRefreshAt: NOW,
     lastRefreshStartedAt: 0,
     lastErrorMessage: null,
     rateLimitedUntilMs: 0,
@@ -85,921 +103,720 @@ function makeValidCache(overrides: Partial<Cache> = {}): Cache {
   };
 }
 
-/**
- * Build a spawnRefresh mock that writes a cache with the given state after
- * being called. Returns the mock function.
- */
-function makeSpawnRefresh(
-  cacheDir: string,
-  cacheOverrides: Partial<Cache> = {},
-): InitDeps['spawnRefresh'] {
-  return vi.fn((_args, _opts) => {
-    const cFile = path.join(cacheDir, '.claude', 'cc-statusline', 'cache.json');
-    const cache = makeValidCache(cacheOverrides);
-    fs.mkdirSync(path.dirname(cFile), { recursive: true, mode: 0o700 });
-    fs.writeFileSync(cFile, JSON.stringify(cache, null, 2) + '\n', 'utf8');
-    return { status: 0 };
-  });
-}
-
-/**
- * Build default deps for testing without touching real ~/.claude/.
- */
-function baseDeps(tmpDir: string, extra: Partial<InitDeps> = {}): InitDeps {
+function baseDeps(tmpDir: string, overrides: Partial<InitDeps> = {}): InitDeps {
   return {
     homedirOverride: tmpDir,
     platformOverride: 'linux',
-    bundlePathOverride: path.join(tmpDir, 'fake-bundle.js'),
+    bundlePathOverride: makeFakeBundle(tmpDir),
     versionString: '1.2.3',
     settingsPath: settingsPath(tmpDir),
     cachePath: cachePath(tmpDir),
     isInteractive: false,
-    ...extra,
+    now: () => NOW,
+    fetchImpl: makeFetch(),
+    discoverImpl: vi.fn().mockResolvedValue(MOCK_CREDENTIALS),
+    spawnClaude: vi.fn(),
+    ...overrides,
   };
 }
 
-function makeFakeBundle(dir: string): string {
-  const p = path.join(dir, 'fake-bundle.js');
-  fs.writeFileSync(p, '#!/usr/bin/env node\n// fake bundle\n', 'utf8');
-  return p;
-}
-
-// Capture stdout during a call
-async function captureStdout(fn: () => Promise<number>): Promise<{ code: number; output: string }> {
+function captureStream(
+  stream: NodeJS.WriteStream,
+  fn: () => Promise<number>,
+): Promise<{ code: number; output: string }> {
   const chunks: string[] = [];
-  const originalWrite = process.stdout.write.bind(process.stdout) as typeof process.stdout.write;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (process.stdout as any).write = (chunk: string | Uint8Array, ...rest: unknown[]) => {
-    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
-    return (originalWrite as (c: string | Uint8Array, ...a: unknown[]) => boolean)(chunk, ...rest);
-  };
-  try {
-    const code = await fn();
-    return { code, output: chunks.join('') };
-  } finally {
-    process.stdout.write = originalWrite;
-  }
+  const writeSpy = vi.spyOn(stream, 'write').mockImplementation(
+    ((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      return true;
+    }) as typeof stream.write,
+  );
+  return fn()
+    .then((code) => ({ code, output: chunks.join('') }))
+    .finally(() => writeSpy.mockRestore());
 }
 
-// Capture stderr during a call
-async function captureStderr(fn: () => Promise<number>): Promise<{ code: number; output: string }> {
-  const chunks: string[] = [];
-  const originalWrite = process.stderr.write.bind(process.stderr) as typeof process.stderr.write;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (process.stderr as any).write = (chunk: string | Uint8Array, ...rest: unknown[]) => {
-    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
-    return (originalWrite as (c: string | Uint8Array, ...a: unknown[]) => boolean)(chunk, ...rest);
-  };
-  try {
-    const code = await fn();
-    return { code, output: chunks.join('') };
-  } finally {
-    process.stderr.write = originalWrite;
-  }
+function captureStdout(fn: () => Promise<number>): Promise<{ code: number; output: string }> {
+  return captureStream(process.stdout, fn);
 }
 
-// ---------------------------------------------------------------------------
-// Test 1: Happy path (Pro/Max, interactive) — user picks 1 (Pro)
-// ---------------------------------------------------------------------------
+function captureStderr(fn: () => Promise<number>): Promise<{ code: number; output: string }> {
+  return captureStream(process.stderr, fn);
+}
 
-describe('T1: happy path Pro interactive', () => {
-  it('picks Pro at the prompt; copies bundle; sets render-promax command; no cache.json; no discover', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    const discoverSpy = vi.fn();
-    const spawnSpy = vi.fn();
-
-    // stdinReader returns '1' for Pro
-    const deps = baseDeps(tmpDir, {
-      isInteractive: true,
-      stdinReader: vi.fn().mockResolvedValue('1'),
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const code = await runInit([], deps);
-    expect(code).toBe(0);
-
-    // Bundle was copied
-    expect(fs.existsSync(bundlePath(tmpDir))).toBe(true);
-
-    // Settings has render-promax
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-promax/);
-
-    // No cache.json (R3)
-    expect(fs.existsSync(cachePath(tmpDir))).toBe(false);
-
-    // No discover calls
-    expect(discoverSpy).not.toHaveBeenCalled();
-
-    // No spawn calls
-    expect(spawnSpy).not.toHaveBeenCalled();
+function authRecoveryDeps(
+  tmpDir: string,
+  statusResult: SpawnClaudeResult,
+  loginResult: SpawnClaudeResult = { status: 0, signal: null },
+) {
+  const discoverImpl = vi.fn()
+    .mockRejectedValueOnce(new CredentialNotFoundError(['/mock/credentials.json']))
+    .mockResolvedValueOnce(MOCK_CREDENTIALS);
+  const spawnClaude = vi.fn((
+    _command: string,
+    argv: readonly string[],
+    _options: Parameters<NonNullable<InitDeps['spawnClaude']>>[2],
+  ) => {
+    return argv[1] === 'status' ? statusResult : loginResult;
   });
-});
+  const deps = baseDeps(tmpDir, {
+    isInteractive: true,
+    discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+    spawnClaude,
+  });
+  return {
+    deps,
+    spawnClaude,
+    discoverImpl,
+  };
+}
 
-// ---------------------------------------------------------------------------
-// Test 2: Happy path (Pro/Max, non-interactive) — --plan=pro
-// ---------------------------------------------------------------------------
-
-describe('T2: happy path Pro non-interactive --plan=pro', () => {
-  it('short-circuits the prompt; copies bundle; sets render-promax; no cache', async () => {
+describe('plan selection and Pro/Max installation', () => {
+  it.each([
+    [['--plan=pro'], 'pro'],
+    [['--plan', 'max'], 'max'],
+  ])('accepts %j without reading stdin', async (args) => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
+    const stdinReader = vi.fn();
+    const deps = baseDeps(tmpDir, { stdinReader, isInteractive: true });
 
-    const deps = baseDeps(tmpDir, { isInteractive: false });
-
-    const code = await runInit(['--plan=pro'], deps);
-    expect(code).toBe(0);
-
-    expect(fs.existsSync(bundlePath(tmpDir))).toBe(true);
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-promax/);
+    expect(await runInit(args, deps)).toBe(0);
+    expect(stdinReader).not.toHaveBeenCalled();
+    expect(readSettings(settingsPath(tmpDir)).statusLine?.command).toContain('render-promax');
     expect(fs.existsSync(cachePath(tmpDir))).toBe(false);
   });
 
-  it('accepts --plan with a separate value', async () => {
+  it('prompts for a plan only when interaction is available', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
+    const stdinReader = vi.fn().mockResolvedValue('1');
 
-    const deps = baseDeps(tmpDir, { isInteractive: false });
+    expect(await runInit([], baseDeps(tmpDir, { isInteractive: true, stdinReader }))).toBe(0);
+    expect(stdinReader).toHaveBeenCalledOnce();
+  });
 
-    const code = await runInit(['--plan', 'pro'], deps);
-    expect(code).toBe(0);
+  it('requires --plan in non-interactive mode without reading stdin', async () => {
+    const tmpDir = makeTmpDir();
+    const stdinReader = vi.fn();
+    const { code, output } = await captureStderr(() =>
+      runInit(['--non-interactive'], baseDeps(tmpDir, { isInteractive: true, stdinReader })),
+    );
 
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-promax/);
-    expect(fs.existsSync(cachePath(tmpDir))).toBe(false);
+    expect(code).toBe(1);
+    expect(output).toContain('--plan');
+    expect(stdinReader).not.toHaveBeenCalled();
+    expect(fs.existsSync(bundlePath(tmpDir))).toBe(false);
   });
 });
 
-// ---------------------------------------------------------------------------
-// Test 3: Happy path (Enterprise, interactive, macOS)
-// ---------------------------------------------------------------------------
-
-describe('T3: happy path Enterprise interactive macOS', () => {
-  it('discovers via mock; writes initial cache; invokes refresh; settings updated; spawn called once', async () => {
+describe('guided Claude Code authentication recovery', () => {
+  it('--plan skips only plan selection and still launches login with an injected TTY', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
+    const { deps, spawnClaude } = authRecoveryDeps(
+      tmpDir,
+      { status: 0, signal: null, stdout: '{"loggedIn":false}' },
+    );
 
-    const discoverSpy = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
+    expect(await runInit(['--plan=enterprise'], deps)).toBe(0);
+    expect(spawnClaude).toHaveBeenCalledTimes(2);
+  });
 
-    const deps = baseDeps(tmpDir, {
-      platformOverride: 'darwin',
+  it.each([
+    ['logged out with documented exit 1', { status: 1, signal: null, stdout: '{"loggedIn":false}' }],
+    ['logged in', { status: 0, signal: null, stdout: '{"loggedIn":true}' }],
+    ['malformed output', { status: 0, signal: null, stdout: 'not json' }],
+    ['missing CLI', { status: null, signal: null, error: Object.assign(new Error('missing'), { code: 'ENOENT' }) }],
+  ] satisfies Array<[string, SpawnClaudeResult]>)(
+    'treats status result %s as explanatory and invokes exactly one login',
+    async (_label, statusResult) => {
+      const tmpDir = makeTmpDir();
+      const { deps, spawnClaude, discoverImpl } = authRecoveryDeps(tmpDir, statusResult);
+
+      expect(await runInit(['--plan=enterprise'], deps)).toBe(0);
+      expect(spawnClaude).toHaveBeenCalledTimes(2);
+      expect(spawnClaude.mock.calls.map((call) => call[1])).toEqual([
+        ['auth', 'status'],
+        ['auth', 'login'],
+      ]);
+      expect(discoverImpl).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('uses exact safe status and login subprocess options', async () => {
+    const tmpDir = makeTmpDir();
+    const { deps, spawnClaude } = authRecoveryDeps(
+      tmpDir,
+      { status: 0, signal: null, stdout: '{"loggedIn":true}' },
+    );
+
+    expect(await runInit(['--plan', 'enterprise'], deps)).toBe(0);
+
+    const statusCall = spawnClaude.mock.calls[0];
+    const loginCall = spawnClaude.mock.calls[1];
+    expect(statusCall?.[0]).toBe('claude');
+    expect(statusCall?.[1]).toEqual(['auth', 'status']);
+    expect(statusCall?.[2]).toMatchObject({
+      shell: false,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+      encoding: 'utf8',
+    });
+    expect(loginCall?.[0]).toBe('claude');
+    expect(loginCall?.[1]).toEqual(['auth', 'login']);
+    expect(loginCall?.[2]).toMatchObject({
+      shell: false,
+      stdio: 'inherit',
+    });
+    expect(loginCall?.[2]).not.toHaveProperty('timeout');
+    expect(Object.keys(statusCall?.[2].env ?? {}).sort()).toEqual(['HOME', 'PATH']);
+  });
+
+  it('rediscovers once and validates once after login, without looping', async () => {
+    const tmpDir = makeTmpDir();
+    const fetchImpl = makeFetch();
+    const { deps, spawnClaude, discoverImpl } = authRecoveryDeps(
+      tmpDir,
+      { status: 1, signal: null, stdout: '' },
+    );
+    deps.fetchImpl = fetchImpl;
+
+    expect(await runInit(['--plan=enterprise'], deps)).toBe(0);
+    expect(discoverImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(spawnClaude).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats an automatic usage 401 as auth failure and recovers once', async () => {
+    const tmpDir = makeTmpDir();
+    const discoverImpl = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
+    const spawnClaude = vi.fn((
+      _command: string,
+      argv: readonly string[],
+      _options: Parameters<NonNullable<InitDeps['spawnClaude']>>[2],
+    ) => argv[1] === 'status'
+      ? { status: 0, signal: null, stdout: '{"loggedIn":true}' }
+      : { status: 0, signal: null });
+    const fetchImpl = (vi.fn()
+      .mockResolvedValueOnce(new Response(undefined, { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(MOCK_USAGE), { status: 200 }))
+    ) as unknown as typeof fetch;
+
+    expect(await runInit(['--plan=enterprise'], baseDeps(tmpDir, {
       isInteractive: true,
-      stdinReader: vi.fn().mockResolvedValue('3'),
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const { code, output } = await captureStdout(() => runInit([], deps));
-    expect(code).toBe(0);
-
-    // Discover was called
-    expect(discoverSpy).toHaveBeenCalledOnce();
-    // Spawn refresh was called once
-    expect(spawnSpy).toHaveBeenCalledOnce();
-
-    // Settings has render-enterprise
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-enterprise/);
-
-    // Cache exists
-    const cache = readCache(cachePath(tmpDir));
-    expect(cache).not.toBeNull();
-    expect(cache?.authState).toBe('ok');
-
-    // Output includes success message
-    expect(output).toContain('Enterprise statusline installed');
-
-    // Always Allow banner printed on macOS
-    expect(output).toContain('Always Allow');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 4: Happy path (Enterprise, non-interactive with --credentials-path)
-// ---------------------------------------------------------------------------
-
-describe('T4: happy path Enterprise non-interactive with --credentials-path', () => {
-  it('reads from specified path; skips discover; completes install', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    // Write a valid credentials file inside homedir
-    const credFile = path.join(tmpDir, '.claude', 'test-creds.json');
-    fs.mkdirSync(path.dirname(credFile), { recursive: true });
-    fs.writeFileSync(credFile, JSON.stringify(VALID_ENVELOPE), 'utf8');
-
-    const discoverSpy = vi.fn();
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const code = await runInit(
-      [`--plan=enterprise`, `--credentials-path=${credFile}`],
-      deps,
-    );
-    expect(code).toBe(0);
-
-    // No discover called
-    expect(discoverSpy).not.toHaveBeenCalled();
-
-    // Cache written
-    const cache = readCache(cachePath(tmpDir));
-    expect(cache).not.toBeNull();
-    expect(cache?.authState).toBe('ok');
-
-    // Settings has render-enterprise
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-enterprise/);
+      discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+      spawnClaude,
+      fetchImpl,
+    }))).toBe(0);
+    expect(discoverImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(spawnClaude).toHaveBeenCalledTimes(2);
   });
 
-  it('accepts --plan enterprise with a separate value', async () => {
+  it('recovers expired automatic credentials and samples time through persistence', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
+    const postLoginCredentials = {
+      ...MOCK_CREDENTIALS,
+      accessToken: 'sk-ant-post-login',
+      expiresAt: NOW + 1_500,
+    };
+    const discoverImpl = vi.fn()
+      .mockResolvedValueOnce({ ...MOCK_CREDENTIALS, expiresAt: NOW })
+      .mockResolvedValueOnce(postLoginCredentials);
+    const spawnClaude = vi.fn((
+      _command: string,
+      argv: readonly string[],
+      _options: Parameters<NonNullable<InitDeps['spawnClaude']>>[2],
+    ) => argv[1] === 'status'
+      ? { status: 0, signal: null, stdout: '{"loggedIn":true}' }
+      : { status: 0, signal: null });
+    const now = vi.fn()
+      .mockReturnValueOnce(NOW)
+      .mockReturnValueOnce(NOW + 1_000)
+      .mockReturnValueOnce(NOW + 2_000);
+    const fetchImpl = makeFetch();
 
-    const credFile = path.join(tmpDir, '.claude', 'test-creds.json');
-    fs.mkdirSync(path.dirname(credFile), { recursive: true });
-    fs.writeFileSync(credFile, JSON.stringify(VALID_ENVELOPE), 'utf8');
-
-    const discoverSpy = vi.fn();
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const code = await runInit(
-      ['--plan', 'enterprise', `--credentials-path=${credFile}`, '--force'],
-      deps,
-    );
-    expect(code).toBe(0);
-    expect(discoverSpy).not.toHaveBeenCalled();
-    expect(spawnSpy).toHaveBeenCalledOnce();
-
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-enterprise/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 5: AE5 — settings conflict, interactive, user says 'n'
-// ---------------------------------------------------------------------------
-
-describe('T5: AE5 settings conflict interactive answer n', () => {
-  it('existing statusLine.command differs; user says n; settings.json unchanged; no cache; exit 0', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    // Write settings with an existing different command
-    writeJson(settingsPath(tmpDir), {
-      statusLine: { type: 'command', command: '/other/tool render-something' },
-    });
-
-    const deps = baseDeps(tmpDir, {
+    expect(await runInit(['--plan=enterprise'], baseDeps(tmpDir, {
       isInteractive: true,
-      stdinReader: vi.fn()
-        .mockResolvedValueOnce('1')   // plan choice
-        .mockResolvedValueOnce('n'),  // conflict prompt
+      discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+      spawnClaude,
+      now,
+      fetchImpl,
+    }))).toBe(0);
+
+    expect(discoverImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(spawnClaude.mock.calls.map((call) => call[1])).toEqual([
+      ['auth', 'status'],
+      ['auth', 'login'],
+    ]);
+    expect(now).toHaveBeenCalledTimes(3);
+    expect(readCache(cachePath(tmpDir))).toMatchObject({
+      credentials: {
+        accessToken: postLoginCredentials.accessToken,
+        expiresAt: postLoginCredentials.expiresAt,
+      },
+      credentialSource: { kind: 'claude-code' },
+      usage: MOCK_USAGE,
+      lastUsageRefreshAt: NOW + 2_000,
     });
-
-    const code = await runInit([], deps);
-    expect(code).toBe(0);
-
-    // Settings unchanged
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toBe('/other/tool render-something');
-
-    // No cache
-    expect(fs.existsSync(cachePath(tmpDir))).toBe(false);
+    expect(fs.readFileSync(cachePath(tmpDir), 'utf8')).not.toContain('refreshToken');
   });
-});
 
-// ---------------------------------------------------------------------------
-// Test 6: Conflict, non-interactive, no --force
-// ---------------------------------------------------------------------------
-
-describe('T6: conflict non-interactive no --force', () => {
-  it('exits with code 2; settings unchanged', async () => {
+  it('does not launch login when initial discovery fails for a reason other than missing credentials', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    writeJson(settingsPath(tmpDir), {
-      statusLine: { type: 'command', command: '/other/tool render-something' },
-    });
-
-    const deps = baseDeps(tmpDir, { isInteractive: false });
-
-    const { code } = await captureStderr(() => runInit(['--plan=pro'], deps));
-    expect(code).toBe(2);
-
-    // Settings unchanged
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toBe('/other/tool render-something');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 7: Conflict with --force
-// ---------------------------------------------------------------------------
-
-describe('T7: conflict with --force', () => {
-  it('settings overwritten without prompt; exits 0', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    writeJson(settingsPath(tmpDir), {
-      statusLine: { type: 'command', command: '/other/tool render-something' },
-    });
-
-    const deps = baseDeps(tmpDir, { isInteractive: false });
-
-    const code = await runInit(['--plan=pro', '--force'], deps);
-    expect(code).toBe(0);
-
-    // Settings now has our command
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-promax/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 8: Idempotent re-run, Enterprise — cache exists with valid creds, no --force
-// ---------------------------------------------------------------------------
-
-describe('T8: idempotent re-run Enterprise with valid cache', () => {
-  it('macOS spawn NOT invoked; settings re-asserted; exit 0', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    // Pre-write a valid cache
-    const validCache = makeValidCache();
-    await writeCache(validCache, cachePath(tmpDir));
-
-    const discoverSpy = vi.fn();
-    const spawnSpy = vi.fn();
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const code = await runInit(['--plan=enterprise'], deps);
-    expect(code).toBe(0);
-
-    // Discover NOT called
-    expect(discoverSpy).not.toHaveBeenCalled();
-    // Spawn NOT called
-    expect(spawnSpy).not.toHaveBeenCalled();
-
-    // Settings has render-enterprise
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-enterprise/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 9: Enterprise validation auth-fatal
-// ---------------------------------------------------------------------------
-
-describe('T9: Enterprise validation auth-fatal', () => {
-  it('mock refresh writes cache with authState=fatal; init prints remediation; exit code 3', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    const discoverSpy = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    const spawnSpy = makeSpawnRefresh(tmpDir, { authState: 'fatal', usage: null, lastErrorMessage: 'Token revoked' });
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const { code, output } = await captureStderr(() => runInit(['--plan=enterprise'], deps));
-    expect(code).toBe(3);
-    expect(output).toMatch(/auth-fatal|expired|revoked/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 10: Enterprise validation cloudflare-blocked
-// ---------------------------------------------------------------------------
-
-describe('T10: Enterprise validation cloudflare-blocked', () => {
-  it('mock refresh writes cache with authState=cloudflare-blocked; Cloudflare-specific message; exit code 3', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    const discoverSpy = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    const spawnSpy = makeSpawnRefresh(tmpDir, { authState: 'cloudflare-blocked', usage: null, lastErrorMessage: 'Cloudflare blocked' });
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const { code, output } = await captureStderr(() => runInit(['--plan=enterprise'], deps));
-    expect(code).toBe(3);
-    expect(output).toMatch(/cloudflare|network|VPN/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 11: Enterprise validation transient — usage=null, lastErrorMessage set
-// ---------------------------------------------------------------------------
-
-describe('T11: Enterprise validation transient', () => {
-  it('mock refresh leaves authState=ok but usage=null with lastErrorMessage; exit code 4', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    const discoverSpy = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    const spawnSpy = makeSpawnRefresh(tmpDir, {
-      authState: 'ok',
-      usage: null,
-      lastErrorMessage: 'Transient network error',
-    });
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const { code, output } = await captureStdout(() => runInit(['--plan=enterprise'], deps));
-    expect(code).toBe(4);
-    expect(output).toContain('could not contact the usage API; retry later');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 12: CredentialNotFoundError, interactive — prompts for paste
-// ---------------------------------------------------------------------------
-
-import { CredentialNotFoundError } from '../src/credentials/discover';
-
-describe('T12: CredentialNotFoundError interactive paste flow', () => {
-  it('discover throws; user prompted for paste; valid paste proceeds; invalid re-prompts (max 3; 3rd failure exits non-zero)', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    const discoverSpy = vi.fn().mockRejectedValue(
-      new CredentialNotFoundError(['macOS keychain', '/fake/.credentials.json']),
-    );
-
-    // First paste is invalid JSON, second is invalid envelope, third is valid
-    const validEnvelopeStr = JSON.stringify(VALID_ENVELOPE);
-    const pasteReader = vi.fn()
-      .mockResolvedValueOnce('not-json-at-all')
-      .mockResolvedValueOnce(JSON.stringify({ claudeAiOauth: {} })) // missing fields
-      .mockResolvedValueOnce(validEnvelopeStr);
-
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
-
-    const deps = baseDeps(tmpDir, {
-      isInteractive: true,
-      stdinReader: vi.fn().mockResolvedValue('3'), // choose enterprise
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      pasteReader,
-      spawnRefresh: spawnSpy,
-    });
-
-    const code = await runInit([], deps);
-    // After 3rd attempt (valid), should succeed
-    expect(code).toBe(0);
-    expect(pasteReader).toHaveBeenCalledTimes(3);
-
-    // 3-failure case: all invalid
-    const tmpDir2 = makeTmpDir();
-    makeFakeBundle(tmpDir2);
-    const discoverSpy2 = vi.fn().mockRejectedValue(
-      new CredentialNotFoundError(['macOS keychain', '/fake/.credentials.json']),
-    );
-    const pasteReader2 = vi.fn().mockResolvedValue('not-json-at-all');
-
-    const { code: code2 } = await captureStderr(() =>
-      runInit([], baseDeps(tmpDir2, {
+    await writeCache(makeCache(), cachePath(tmpDir));
+    const before = fileHash(cachePath(tmpDir));
+    const rawError = `malformed credential ${MOCK_CREDENTIALS.accessToken}`;
+    const discoverImpl = vi.fn().mockRejectedValue(new Error(rawError));
+    const spawnClaude = vi.fn();
+    const { code, output } = await captureStderr(() =>
+      runInit(['--plan=enterprise', '--force'], baseDeps(tmpDir, {
         isInteractive: true,
-        stdinReader: vi.fn().mockResolvedValue('3'),
-        discoverImpl: discoverSpy2 as InitDeps['discoverImpl'],
-        pasteReader: pasteReader2,
-        spawnRefresh: vi.fn(),
+        discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+        spawnClaude,
       })),
     );
-    expect(code2).toBe(2);
-    expect(pasteReader2).toHaveBeenCalledTimes(3);
+
+    expect(code).toBe(3);
+    expect(output).toBe('init: could not read Claude Code credentials.\n');
+    expect(output).not.toContain(rawError);
+    expect(spawnClaude).not.toHaveBeenCalled();
+    expect(fileHash(cachePath(tmpDir))).toBe(before);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Test 13: CredentialNotFoundError, non-interactive
-// ---------------------------------------------------------------------------
-
-describe('T13: CredentialNotFoundError non-interactive', () => {
-  it('discover throws; exits non-zero; message includes paths tried', async () => {
+  it.each([
+    ['explicit non-interactive mode', ['--plan=enterprise', '--non-interactive'], true],
+    ['no TTY', ['--plan=enterprise'], false],
+  ])('prints manual commands and runs no Claude commands for %s', async (_label, args, interactive) => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
+    const discoverImpl = vi.fn().mockRejectedValue(
+      new CredentialNotFoundError(['/mock/credentials.json']),
+    );
+    const spawnClaude = vi.fn();
+    const { code, output } = await captureStderr(() =>
+      runInit(args, baseDeps(tmpDir, {
+        isInteractive: interactive,
+        discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+        spawnClaude,
+      })),
+    );
 
-    const pathsTried = ['macOS keychain', '/home/user/.claude/.credentials.json'];
-    const discoverSpy = vi.fn().mockRejectedValue(new CredentialNotFoundError(pathsTried));
-
-    const deps = baseDeps(tmpDir, {
-      isInteractive: false,
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-    });
-
-    const { code, output } = await captureStderr(() => runInit(['--plan=enterprise'], deps));
     expect(code).toBe(2);
-    expect(output).toContain(pathsTried[0]);
-    expect(output).toContain(pathsTried[1]);
+    expect(output.split('\n')).toContain('claude auth login');
+    expect(output.split('\n')).toContain('npx @nkootstra/cc-statusline --plan enterprise');
+    expect(spawnClaude).not.toHaveBeenCalled();
   });
-});
 
-// ---------------------------------------------------------------------------
-// Test 14: Windows path emission
-// ---------------------------------------------------------------------------
-
-describe('T14: Windows path emission', () => {
-  it('on win32, command is node <absolute>\\cc-statusline.js render-promax; on POSIX, no node prefix', async () => {
-    // Windows
+  it('returns 130 when login is interrupted by SIGINT', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-    const depsWin = baseDeps(tmpDir, { platformOverride: 'win32', isInteractive: false });
-    await runInit(['--plan=pro'], depsWin);
-    const sWin = readSettings(settingsPath(tmpDir));
-    expect(sWin.statusLine?.command).toMatch(/^node /);
-    expect(sWin.statusLine?.command).toMatch(/render-promax/);
+    const previous = makeCache();
+    await writeCache(previous, cachePath(tmpDir));
+    const before = fileHash(cachePath(tmpDir));
+    const { deps, spawnClaude, discoverImpl } = authRecoveryDeps(
+      tmpDir,
+      { status: 0, signal: null, stdout: '{"loggedIn":false}' },
+      { status: null, signal: 'SIGINT' },
+    );
 
-    // POSIX (linux)
-    const tmpDir2 = makeTmpDir();
-    makeFakeBundle(tmpDir2);
-    const depsLinux = baseDeps(tmpDir2, { platformOverride: 'linux', isInteractive: false });
-    await runInit(['--plan=pro'], depsLinux);
-    const sLinux = readSettings(settingsPath(tmpDir2));
-    expect(sLinux.statusLine?.command).not.toMatch(/^node /);
-    expect(sLinux.statusLine?.command).toMatch(/render-promax/);
+    expect(await runInit(['--plan=enterprise', '--force'], deps)).toBe(130);
+    expect(spawnClaude).toHaveBeenCalledTimes(2);
+    expect(discoverImpl).toHaveBeenCalledOnce();
+    expect(fileHash(cachePath(tmpDir))).toBe(before);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Test 15: Absolute path — no ~ in emitted command
-// ---------------------------------------------------------------------------
-
-describe('T15: absolute path — no tilde', () => {
-  it('emitted statusLine.command starts with resolved homedir, never contains ~', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-    const deps = baseDeps(tmpDir, { isInteractive: false });
-
-    await runInit(['--plan=pro'], deps);
-
-    const s = readSettings(settingsPath(tmpDir));
-    const cmd = s.statusLine?.command ?? '';
-    expect(cmd).not.toContain('~/');
-    expect(cmd).not.toContain('~\\');
-    // Should start with the install dir (which is inside tmpDir)
-    expect(path.isAbsolute(cmd.replace(/^node /, ''))).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 16: POSIX file mode — cc-statusline.js is mode 0o755 after copy
-// ---------------------------------------------------------------------------
-
-describe('T16: POSIX file mode', () => {
-  it('on POSIX, cc-statusline.js has mode 0o755 after copy', async () => {
-    if (process.platform === 'win32') return;
-
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-    const deps = baseDeps(tmpDir, { platformOverride: 'linux', isInteractive: false });
-
-    await runInit(['--plan=pro'], deps);
-
-    const mode = fs.statSync(bundlePath(tmpDir)).mode & 0o777;
-    expect(mode).toBe(0o755);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 17: Always re-copy — two invocations; byte-identical after second
-// ---------------------------------------------------------------------------
-
-describe('T17: always re-copy', () => {
-  it('invoke init twice; file at installDir is byte-identical to bundlePathOverride', async () => {
-    const tmpDir = makeTmpDir();
-    const fakeBundle = makeFakeBundle(tmpDir);
-    const deps = baseDeps(tmpDir, { isInteractive: false });
-
-    await runInit(['--plan=pro'], deps);
-
-    // Modify the file at installDir to differ
-    fs.writeFileSync(bundlePath(tmpDir), '// different content\n', 'utf8');
-
-    // Second invocation should re-copy
-    await runInit(['--plan=pro'], deps);
-
-    // Should now be identical to the fake bundle
-    expect(fileHash(bundlePath(tmpDir))).toBe(fileHash(fakeBundle));
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 18: --credentials-path traversal rejection
-// ---------------------------------------------------------------------------
-
-describe('T18: --credentials-path traversal rejection', () => {
-  it('an existing file outside homedir is rejected because it escapes homedir; exit code 2', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-    const deps = baseDeps(tmpDir);
-    const outsideFile = path.join(os.tmpdir(), `cc-outside-creds-${Date.now()}.json`);
-    fs.writeFileSync(outsideFile, JSON.stringify(VALID_ENVELOPE), 'utf8');
-
-    try {
-      const { code, output } = await captureStderr(() =>
-        runInit(['--plan=enterprise', `--credentials-path=${outsideFile}`], deps),
+  it.each([
+    ['nonzero exit', { status: 1, signal: null }],
+    ['missing executable', { status: null, signal: null, error: Object.assign(new Error('missing'), { code: 'ENOENT' }) }],
+    ['other signal', { status: null, signal: 'SIGTERM' }],
+  ] satisfies Array<[string, SpawnClaudeResult]>)(
+    'returns auth error for login %s',
+    async (_label, loginResult) => {
+      const tmpDir = makeTmpDir();
+      await writeCache(makeCache(), cachePath(tmpDir));
+      const before = fileHash(cachePath(tmpDir));
+      const { deps, spawnClaude, discoverImpl } = authRecoveryDeps(
+        tmpDir,
+        { status: 0, signal: null, stdout: '{"loggedIn":false}' },
+        loginResult,
       );
-      expect(code).toBe(2);
-      expect(output).toMatch(/outside home|escapes|homedir/i);
-    } finally {
-      fs.rmSync(outsideFile, { force: true });
-    }
+
+      expect(await runInit(['--plan=enterprise', '--force'], deps)).toBe(3);
+      expect(spawnClaude).toHaveBeenCalledTimes(2);
+      expect(discoverImpl).toHaveBeenCalledOnce();
+      expect(fileHash(cachePath(tmpDir))).toBe(before);
+    },
+  );
+
+  it('preserves the previous cache when post-login validation still fails', async () => {
+    const tmpDir = makeTmpDir();
+    await writeCache(makeCache(), cachePath(tmpDir));
+    const before = fileHash(cachePath(tmpDir));
+    const { deps, spawnClaude } = authRecoveryDeps(
+      tmpDir,
+      { status: 0, signal: null, stdout: '{"loggedIn":true}' },
+    );
+    deps.fetchImpl = makeFetch(401);
+
+    expect(await runInit(['--plan=enterprise', '--force'], deps)).toBe(3);
+    expect(spawnClaude).toHaveBeenCalledTimes(2);
+    expect(fileHash(cachePath(tmpDir))).toBe(before);
   });
+
+  it.each([
+    [
+      'credentials remain missing',
+      new CredentialNotFoundError(['/mock/credentials.json']),
+    ],
+    [
+      'credential source cannot be read',
+      new Error(`malformed credential ${MOCK_CREDENTIALS.accessToken}`),
+    ],
+  ])(
+    'returns a stable error and preserves the previous cache when post-login %s',
+    async (_label, rediscoveryError) => {
+      const tmpDir = makeTmpDir();
+      await writeCache(makeCache(), cachePath(tmpDir));
+      const before = fileHash(cachePath(tmpDir));
+      const discoverImpl = vi.fn()
+        .mockRejectedValueOnce(new CredentialNotFoundError(['/mock/credentials.json']))
+        .mockRejectedValueOnce(rediscoveryError);
+      const spawnClaude = vi.fn((
+        _command: string,
+        argv: readonly string[],
+        _options: Parameters<NonNullable<InitDeps['spawnClaude']>>[2],
+      ) => argv[1] === 'status'
+        ? { status: 1, signal: null, stdout: '{"loggedIn":false}' }
+        : { status: 0, signal: null });
+      const { code, output } = await captureStderr(() =>
+        runInit(['--plan=enterprise', '--force'], baseDeps(tmpDir, {
+          isInteractive: true,
+          discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+          spawnClaude,
+        })),
+      );
+
+      expect(code).toBe(3);
+      expect(output).toBe(
+        'init: Claude Code credentials were not available after login.\n',
+      );
+      expect(output).not.toContain(MOCK_CREDENTIALS.accessToken);
+      expect(spawnClaude).toHaveBeenCalledTimes(2);
+      expect(discoverImpl).toHaveBeenCalledTimes(2);
+      expect(fileHash(cachePath(tmpDir))).toBe(before);
+    },
+  );
 });
 
-// ---------------------------------------------------------------------------
-// Test 19: --credentials-path symlink-out rejection
-// ---------------------------------------------------------------------------
-
-describe('T19: --credentials-path symlink-out rejection', () => {
-  it('symlink in tmpDir pointing to /etc/passwd is rejected via realpath', async () => {
-    if (process.platform === 'win32') return; // symlinks are tricky on Windows
-
+describe('credential validation and cache persistence', () => {
+  it('uses a valid unexpired v4 cache without discovery, auth commands, or network', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
+    await writeCache(makeCache(), cachePath(tmpDir));
+    const discoverImpl = vi.fn();
+    const spawnClaude = vi.fn();
+    const fetchImpl = makeFetch();
 
-    // Create symlink in tmpDir pointing outside
-    const symlinkPath = path.join(tmpDir, 'evil-link.json');
-    try {
-      fs.symlinkSync('/etc/passwd', symlinkPath);
-    } catch {
-      // Skip if we can't create symlinks
-      return;
-    }
+    expect(await runInit(['--plan=enterprise'], baseDeps(tmpDir, {
+      discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+      spawnClaude,
+      fetchImpl,
+    }))).toBe(0);
+    expect(discoverImpl).not.toHaveBeenCalled();
+    expect(spawnClaude).not.toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 
-    const deps = baseDeps(tmpDir);
+  it('validates a direct automatic candidate without auth commands', async () => {
+    const tmpDir = makeTmpDir();
+    const discoverImpl = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
+    const spawnClaude = vi.fn();
+    const fetchImpl = makeFetch();
+
+    expect(await runInit(['--plan=enterprise'], baseDeps(tmpDir, {
+      discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+      spawnClaude,
+      fetchImpl,
+    }))).toBe(0);
+    expect(discoverImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(spawnClaude).not.toHaveBeenCalled();
+
+    const cache = readCache(cachePath(tmpDir));
+    expect(cache).toMatchObject({
+      schemaVersion: 4,
+      authState: 'ok',
+      credentials: {
+        accessToken: MOCK_CREDENTIALS.accessToken,
+        expiresAt: MOCK_CREDENTIALS.expiresAt,
+      },
+      credentialSource: { kind: 'claude-code' },
+      usage: MOCK_USAGE,
+      lastUsageRefreshAt: NOW,
+      lastRefreshStartedAt: 0,
+      lastErrorMessage: null,
+      rateLimitedUntilMs: 0,
+      nextRefreshAllowedAt: 0,
+      consecutiveRateLimitCount: 0,
+    });
+    expect(fs.readFileSync(cachePath(tmpDir), 'utf8')).not.toContain('refreshToken');
+  });
+
+  it('an explicit path bypasses a valid cache, stores its canonical source, and never runs auth commands', async () => {
+    const tmpDir = makeTmpDir();
+    await writeCache(makeCache(), cachePath(tmpDir));
+    const credentialsFile = path.join(tmpDir, '.claude', 'credentials.json');
+    writeJson(credentialsFile, { claudeAiOauth: MOCK_CREDENTIALS });
+    const discoverImpl = vi.fn();
+    const spawnClaude = vi.fn();
+    const fetchImpl = makeFetch();
+
+    expect(await runInit([
+      '--plan=enterprise',
+      `--credentials-path=${credentialsFile}`,
+    ], baseDeps(tmpDir, {
+      discoverImpl: discoverImpl as InitDeps['discoverImpl'],
+      spawnClaude,
+      fetchImpl,
+    }))).toBe(0);
+    expect(discoverImpl).not.toHaveBeenCalled();
+    expect(spawnClaude).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(readCache(cachePath(tmpDir))?.credentialSource).toEqual({
+      kind: 'file',
+      path: fs.realpathSync(credentialsFile),
+    });
+  });
+
+  it.each([
+    ['expired credentials', 'expired', 3],
+    ['usage 401', 401, 3],
+    ['usage 403', 403, 4],
+    ['usage 429', 429, 4],
+    ['usage 500', 500, 4],
+    ['network timeout', 'timeout', 4],
+  ])('classifies explicit-path %s and preserves the previous cache', async (_label, outcome, expectedCode) => {
+    const tmpDir = makeTmpDir();
+    await writeCache(makeCache(), cachePath(tmpDir));
+    const before = fileHash(cachePath(tmpDir));
+    const credentialsFile = path.join(tmpDir, '.claude', 'credentials.json');
+    const credentials = outcome === 'expired'
+      ? { ...MOCK_CREDENTIALS, expiresAt: NOW }
+      : MOCK_CREDENTIALS;
+    writeJson(credentialsFile, { claudeAiOauth: credentials });
+    const spawnClaude = vi.fn();
+    const fetchImpl = outcome === 'timeout'
+      ? makeThrowingFetch()
+      : makeFetch(typeof outcome === 'number' ? outcome : 200);
+
+    expect(await runInit([
+      '--plan=enterprise',
+      `--credentials-path=${credentialsFile}`,
+    ], baseDeps(tmpDir, { spawnClaude, fetchImpl }))).toBe(expectedCode);
+    expect(spawnClaude).not.toHaveBeenCalled();
+    expect(fileHash(cachePath(tmpDir))).toBe(before);
+  });
+
+  it.each([403, 429, 500])(
+    'treats automatic usage %i as network failure without launching login',
+    async (status) => {
+      const tmpDir = makeTmpDir();
+      await writeCache(makeCache(), cachePath(tmpDir));
+      const before = fileHash(cachePath(tmpDir));
+      const spawnClaude = vi.fn();
+
+      expect(await runInit(['--plan=enterprise', '--force'], baseDeps(tmpDir, {
+        fetchImpl: makeFetch(status),
+        spawnClaude,
+      }))).toBe(4);
+      expect(spawnClaude).not.toHaveBeenCalled();
+      expect(fileHash(cachePath(tmpDir))).toBe(before);
+    },
+  );
+
+  it('treats malformed automatic usage JSON as a retryable network failure', async () => {
+    const tmpDir = makeTmpDir();
+    await writeCache(makeCache(), cachePath(tmpDir));
+    const before = fileHash(cachePath(tmpDir));
+    const spawnClaude = vi.fn();
+    const fetchImpl = vi.fn(async () =>
+      new Response('not-json', { status: 200 }),
+    ) as unknown as typeof fetch;
 
     const { code, output } = await captureStderr(() =>
-      runInit(['--plan=enterprise', `--credentials-path=${symlinkPath}`], deps),
+      runInit(['--plan=enterprise', '--force'], baseDeps(tmpDir, {
+        fetchImpl,
+        spawnClaude,
+      })),
     );
-    expect(code).toBe(2);
-    expect(output).toMatch(/outside home|escapes|homedir/i);
+
+    expect(code).toBe(4);
+    expect(output).toBe('init: could not contact the usage API; retry later.\n');
+    expect(spawnClaude).not.toHaveBeenCalled();
+    expect(fileHash(cachePath(tmpDir))).toBe(before);
   });
 });
 
-// ---------------------------------------------------------------------------
-// Test 20: --credentials-path special-file rejection
-// ---------------------------------------------------------------------------
-
-describe('T20: --credentials-path special-file rejection', () => {
-  it('/dev/zero is rejected (not a regular file); exit code 2', async () => {
-    if (process.platform === 'win32') return; // no /dev/zero on Windows
-
+describe('settings, platform, and installer regressions', () => {
+  it('leaves a conflicting setting unchanged when the interactive user declines', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-    const deps = baseDeps(tmpDir);
-
-    const { code, output } = await captureStderr(() =>
-      runInit(['--plan=enterprise', '--credentials-path=/dev/zero'], deps),
-    );
-    expect(code).toBe(2);
-    // Either "outside home" (realpath shows it's not under homedir) OR "not a regular file"
-    expect(output).toMatch(/outside home|not a regular file|escapes|homedir/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 21: Paste no-echo — pasted bytes do NOT appear in stdout
-// ---------------------------------------------------------------------------
-
-describe('T21: paste no-echo', () => {
-  it('captured stdout during paste prompt does not contain pasted bytes', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    const SECRET = 'my-secret-paste-content-xyz';
-
-    const discoverSpy = vi.fn().mockRejectedValue(
-      new CredentialNotFoundError(['keychain']),
-    );
-    const pasteReader = vi.fn().mockResolvedValueOnce(JSON.stringify(VALID_ENVELOPE));
-
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
-
-    const deps = baseDeps(tmpDir, {
-      isInteractive: true,
-      stdinReader: vi.fn().mockResolvedValue('3'),
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      pasteReader,
-      spawnRefresh: spawnSpy,
-    });
-
-    const { output } = await captureStdout(() => runInit([], deps));
-
-    // The secret paste string should not appear in stdout
-    expect(output).not.toContain(SECRET);
-    // The pasted JSON envelope string should not appear in stdout either
-    expect(output).not.toContain(VALID_ENVELOPE.claudeAiOauth.accessToken);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 22: Initial cache shape — all 6 fields explicit
-// ---------------------------------------------------------------------------
-
-describe('T22: initial cache shape', () => {
-  it('written initial cache has all six Cache fields; readCache returns fully-typed object', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    const discoverSpy = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    // Spawn writes a valid cache with usage
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    // We need to read the cache BEFORE the spawn mock overwrites it, so we
-    // intercept the spawnRefresh to capture the initial cache.
-    let initialCacheSnapshot: Cache | null = null;
-    const captureSpawn: InitDeps['spawnRefresh'] = vi.fn((_args, _opts) => {
-      // Capture the cache written before spawn
-      initialCacheSnapshot = readCache(cachePath(tmpDir));
-      // Then do what makeSpawnRefresh would do
-      const cFile = cachePath(tmpDir);
-      const cache = makeValidCache({ usage: MOCK_USAGE });
-      fs.mkdirSync(path.dirname(cFile), { recursive: true, mode: 0o700 });
-      fs.writeFileSync(cFile, JSON.stringify(cache, null, 2) + '\n', 'utf8');
-      return { status: 0 };
-    });
-
-    const code = await runInit(['--plan=enterprise'], {
-      ...deps,
-      spawnRefresh: captureSpawn,
-    });
-    expect(code).toBe(0);
-
-    // Initial cache (before spawn) must have all expected fields
-    expect(initialCacheSnapshot).not.toBeNull();
-    const c = initialCacheSnapshot!;
-    expect(c.schemaVersion).toBe(3);
-    expect(c.authState).toBe('ok');
-    expect(c.credentials).toBeDefined();
-    expect(c.usage).toBeNull();
-    expect(c.lastUsageRefreshAt).toBe(0);
-    expect(c.lastRefreshStartedAt).toBe(0);
-    expect(c.lastErrorMessage).toBeNull();
-    expect(c.rateLimitedUntilMs).toBe(0);
-
-    // None are undefined
-    const fields: (keyof Cache)[] = [
-      'schemaVersion', 'authState', 'credentials', 'usage',
-      'lastUsageRefreshAt', 'lastRefreshStartedAt', 'lastErrorMessage',
-      'rateLimitedUntilMs', 'nextRefreshAllowedAt', 'consecutiveRateLimitCount',
-    ];
-    for (const field of fields) {
-      expect(c[field]).not.toBeUndefined();
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Test 23: --force unified — bypasses both conflict prompt AND idempotent skip
-// ---------------------------------------------------------------------------
-
-describe('T23: --force unified', () => {
-  it('with --force, settings conflict and idempotent-skip are both bypassed; destructive paths fire', async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-
-    // Existing conflicting settings
     writeJson(settingsPath(tmpDir), {
-      statusLine: { type: 'command', command: '/other/tool render-something' },
+      statusLine: { type: 'command', command: '/other/statusline' },
     });
+    const before = fileHash(settingsPath(tmpDir));
 
-    // Existing valid cache (would normally cause idempotent skip)
-    const validCache = makeValidCache();
-    await writeCache(validCache, cachePath(tmpDir));
-
-    const discoverSpy = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
-
-    const deps = baseDeps(tmpDir, {
-      discoverImpl: discoverSpy as InitDeps['discoverImpl'],
-      spawnRefresh: spawnSpy,
-    });
-
-    const code = await runInit(['--plan=enterprise', '--force'], deps);
-    expect(code).toBe(0);
-
-    // Settings was overwritten
-    const s = readSettings(settingsPath(tmpDir));
-    expect(s.statusLine?.command).toMatch(/render-enterprise/);
-    expect(s.statusLine?.command).not.toBe('/other/tool render-something');
-
-    // Discover was called (idempotent skip was bypassed)
-    expect(discoverSpy).toHaveBeenCalled();
-    // Spawn was called (idempotent skip was bypassed)
-    expect(spawnSpy).toHaveBeenCalled();
+    expect(await runInit([], baseDeps(tmpDir, {
+      isInteractive: true,
+      stdinReader: vi.fn()
+        .mockResolvedValueOnce('1')
+        .mockResolvedValueOnce('n'),
+    }))).toBe(0);
+    expect(fileHash(settingsPath(tmpDir))).toBe(before);
+    expect(fs.existsSync(bundlePath(tmpDir))).toBe(false);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Test 24: Always Allow banner — macOS vs Linux/Windows
-// ---------------------------------------------------------------------------
-
-describe('T24: Always Allow banner macOS vs Linux', () => {
-  it('on darwin Enterprise flow, banner is printed before discover; on linux, banner NOT printed', async () => {
-    // macOS
+  it('does not activate Enterprise installation when authentication fails', async () => {
     const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
+    writeJson(settingsPath(tmpDir), {
+      statusLine: { type: 'command', command: '/other/statusline' },
+    });
+    fs.mkdirSync(path.dirname(bundlePath(tmpDir)), { recursive: true });
+    fs.writeFileSync(bundlePath(tmpDir), 'previous bundle\n', 'utf8');
+    const settingsBefore = fileHash(settingsPath(tmpDir));
+    const bundleBefore = fileHash(bundlePath(tmpDir));
+    const { deps } = authRecoveryDeps(
+      tmpDir,
+      { status: 0, signal: null, stdout: '{"loggedIn":false}' },
+      { status: 1, signal: null },
+    );
 
-    const discoverSpy = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    const spawnSpy = makeSpawnRefresh(tmpDir, { usage: MOCK_USAGE });
-    const capturedMessages: string[] = [];
-    const originalDiscoverSpy = vi.fn(async (..._args: unknown[]) => {
-      // Record the stdout so far at the time discover is called
-      capturedMessages.push(...stdoutSoFar);
-      return MOCK_CREDENTIALS;
+    expect(await runInit(['--plan=enterprise', '--force'], deps)).toBe(3);
+    expect(fileHash(settingsPath(tmpDir))).toBe(settingsBefore);
+    expect(fileHash(bundlePath(tmpDir))).toBe(bundleBefore);
+    expect(fs.existsSync(cachePath(tmpDir))).toBe(false);
+  });
+
+  it('rejects a settings conflict without interaction and lets --force overwrite it', async () => {
+    const tmpDir = makeTmpDir();
+    writeJson(settingsPath(tmpDir), {
+      statusLine: { type: 'command', command: '/other/statusline' },
     });
 
-    let stdoutSoFar: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout) as typeof process.stdout.write;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (process.stdout as any).write = (chunk: string | Uint8Array, ...rest: unknown[]) => {
-      stdoutSoFar.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
-      return (origWrite as (c: string | Uint8Array, ...a: unknown[]) => boolean)(chunk, ...rest);
-    };
+    expect(await runInit(['--plan=pro'], baseDeps(tmpDir))).toBe(2);
+    expect(readSettings(settingsPath(tmpDir)).statusLine?.command).toBe('/other/statusline');
+    expect(await runInit(['--plan=pro', '--force'], baseDeps(tmpDir))).toBe(0);
+    expect(readSettings(settingsPath(tmpDir)).statusLine?.command).toContain('render-promax');
+  });
 
-    try {
-      const deps = baseDeps(tmpDir, {
-        platformOverride: 'darwin',
-        discoverImpl: originalDiscoverSpy as InitDeps['discoverImpl'],
-        spawnRefresh: spawnSpy,
-      });
-      const code = await runInit(['--plan=enterprise'], deps);
-      expect(code).toBe(0);
-    } finally {
-      process.stdout.write = origWrite;
-    }
+  it('emits platform-specific absolute commands and makes POSIX bundles executable', async () => {
+    const windowsDir = makeTmpDir();
+    expect(await runInit(['--plan=pro'], baseDeps(windowsDir, {
+      platformOverride: 'win32',
+    }))).toBe(0);
+    const windowsCommand = readSettings(settingsPath(windowsDir)).statusLine?.command;
+    expect(windowsCommand).toBe(`node ${bundlePath(windowsDir)} render-promax`);
+    expect(windowsCommand).not.toContain('~');
 
-    const allOutput = stdoutSoFar.join('');
-    expect(allOutput).toContain('Always Allow');
+    const posixDir = makeTmpDir();
+    expect(await runInit(['--plan=pro'], baseDeps(posixDir))).toBe(0);
+    expect(readSettings(settingsPath(posixDir)).statusLine?.command)
+      .toBe(`${bundlePath(posixDir)} render-promax`);
+    expect(fs.statSync(bundlePath(posixDir)).mode & 0o777).toBe(0o755);
+  });
 
-    // Linux — no banner
-    const tmpDir2 = makeTmpDir();
-    makeFakeBundle(tmpDir2);
-    const discoverSpy2 = vi.fn().mockResolvedValue(MOCK_CREDENTIALS);
-    const spawnSpy2 = makeSpawnRefresh(tmpDir2, { usage: MOCK_USAGE });
+  it('always recopies the bundle and logs the installed version', async () => {
+    const tmpDir = makeTmpDir();
+    const source = makeFakeBundle(tmpDir, 'first\n');
+    const deps = baseDeps(tmpDir, { bundlePathOverride: source });
 
+    expect(await runInit(['--plan=pro'], deps)).toBe(0);
+    fs.writeFileSync(source, 'second\n', 'utf8');
+    const { code, output } = await captureStdout(() => runInit(['--plan=pro'], deps));
+    expect(code).toBe(0);
+    expect(fs.readFileSync(bundlePath(tmpDir), 'utf8')).toBe('second\n');
+    expect(output).toMatch(/installed cc-statusline v1\.2\.3/);
+  });
+
+  it('prints the macOS keychain note only for automatic Enterprise discovery', async () => {
+    const macDir = makeTmpDir();
+    const { output: macOutput } = await captureStdout(() =>
+      runInit(['--plan=enterprise'], baseDeps(macDir, { platformOverride: 'darwin' })),
+    );
+    expect(macOutput).toContain('Always Allow');
+
+    const linuxDir = makeTmpDir();
     const { output: linuxOutput } = await captureStdout(() =>
-      runInit(
-        ['--plan=enterprise'],
-        baseDeps(tmpDir2, {
-          platformOverride: 'linux',
-          discoverImpl: discoverSpy2 as InitDeps['discoverImpl'],
-          spawnRefresh: spawnSpy2,
-        }),
-      ),
+      runInit(['--plan=enterprise'], baseDeps(linuxDir)),
     );
     expect(linuxOutput).not.toContain('Always Allow');
   });
 });
 
-// ---------------------------------------------------------------------------
-// Test 25: Version log
-// ---------------------------------------------------------------------------
+describe('explicit credential path security', () => {
+  it('does not print malformed credential contents', async () => {
+    const home = makeTmpDir();
+    const credentialsFile = path.join(home, 'credentials.json');
+    const leakedToken = 'sk-ant-must-not-appear';
+    fs.writeFileSync(
+      credentialsFile,
+      `{"claudeAiOauth":{"accessToken":"${leakedToken}"`,
+      'utf8',
+    );
 
-describe('T25: version log', () => {
-  it("init's stdout includes a line matching /^installed cc-statusline v\\d+\\.\\d+\\.\\d+/", async () => {
-    const tmpDir = makeTmpDir();
-    makeFakeBundle(tmpDir);
-    const deps = baseDeps(tmpDir, {
-      versionString: '1.2.3',
-      isInteractive: false,
-    });
+    const { code, output } = await captureStderr(() =>
+      runInit([
+        '--plan=enterprise',
+        `--credentials-path=${credentialsFile}`,
+      ], baseDeps(home)),
+    );
 
-    const { output } = await captureStdout(() => runInit(['--plan=pro'], deps));
-    expect(output).toMatch(/installed cc-statusline v\d+\.\d+\.\d+/);
-    expect(output).toContain('installed cc-statusline v1.2.3');
+    expect(code).toBe(2);
+    expect(output).toContain('could not read credentials from --credentials-path');
+    expect(output).not.toContain(leakedToken);
+  });
+
+  it('rejects a path outside the home directory', async () => {
+    const home = makeTmpDir();
+    const outside = makeTmpDir();
+    const credentialsFile = path.join(outside, 'credentials.json');
+    writeJson(credentialsFile, { claudeAiOauth: MOCK_CREDENTIALS });
+
+    const { code, output } = await captureStderr(() =>
+      runInit([
+        '--plan=enterprise',
+        `--credentials-path=${credentialsFile}`,
+      ], baseDeps(home)),
+    );
+    expect(code).toBe(2);
+    expect(output).toContain('outside home directory');
+  });
+
+  it('rejects a symlink that resolves outside the home directory', async () => {
+    const home = makeTmpDir();
+    const outside = makeTmpDir();
+    const target = path.join(outside, 'credentials.json');
+    const symlink = path.join(home, 'credentials.json');
+    writeJson(target, { claudeAiOauth: MOCK_CREDENTIALS });
+    fs.symlinkSync(target, symlink);
+
+    const { code } = await captureStderr(() =>
+      runInit([
+        '--plan=enterprise',
+        `--credentials-path=${symlink}`,
+      ], baseDeps(home)),
+    );
+    expect(code).toBe(2);
+  });
+
+  it.runIf(process.platform !== 'win32')('rejects a non-regular file', async () => {
+    const home = makeTmpDir();
+    const directory = path.join(home, 'credentials');
+    fs.mkdirSync(directory);
+
+    const { code, output } = await captureStderr(() =>
+      runInit([
+        '--plan=enterprise',
+        `--credentials-path=${directory}`,
+      ], baseDeps(home)),
+    );
+    expect(code).toBe(2);
+    expect(output).toContain('not a regular file');
   });
 });

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -705,7 +705,7 @@ describe('settings, platform, and installer regressions', () => {
     expect(readSettings(settingsPath(tmpDir)).statusLine?.command).toContain('render-promax');
   });
 
-  it('emits platform-specific absolute commands and makes POSIX bundles executable', async () => {
+  it('emits an absolute node command on Windows', async () => {
     const windowsDir = makeTmpDir();
     expect(await runInit(['--plan=pro'], baseDeps(windowsDir, {
       platformOverride: 'win32',
@@ -714,7 +714,9 @@ describe('settings, platform, and installer regressions', () => {
     const windowsBundlePath = bundlePath(windowsDir);
     expect(path.isAbsolute(windowsBundlePath)).toBe(true);
     expect(windowsCommand).toBe(`node ${windowsBundlePath} render-promax`);
+  });
 
+  it.runIf(process.platform !== 'win32')('makes POSIX bundles executable', async () => {
     const posixDir = makeTmpDir();
     expect(await runInit(['--plan=pro'], baseDeps(posixDir))).toBe(0);
     expect(readSettings(settingsPath(posixDir)).statusLine?.command)

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -581,7 +581,7 @@ describe('credential validation and cache persistence', () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
     expect(readCache(cachePath(tmpDir))?.credentialSource).toEqual({
       kind: 'file',
-      path: fs.realpathSync(credentialsFile),
+      path: await fs.promises.realpath(credentialsFile),
     });
   });
 
@@ -711,8 +711,9 @@ describe('settings, platform, and installer regressions', () => {
       platformOverride: 'win32',
     }))).toBe(0);
     const windowsCommand = readSettings(settingsPath(windowsDir)).statusLine?.command;
-    expect(windowsCommand).toBe(`node ${bundlePath(windowsDir)} render-promax`);
-    expect(windowsCommand).not.toContain('~');
+    const windowsBundlePath = bundlePath(windowsDir);
+    expect(path.isAbsolute(windowsBundlePath)).toBe(true);
+    expect(windowsCommand).toBe(`node ${windowsBundlePath} render-promax`);
 
     const posixDir = makeTmpDir();
     expect(await runInit(['--plan=pro'], baseDeps(posixDir))).toBe(0);

--- a/tests/oauth-client.test.ts
+++ b/tests/oauth-client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { refresh, fetchUsage } from '../src/oauth/client';
+import { describe, it, expect, vi } from 'vitest';
+import { fetchUsage } from '../src/oauth/client';
 import usageFixture from './fixtures/usage-response.json';
 
 // AE7 deferred: the disabled-case shape (extra_usage.is_enabled === false) is unverified
@@ -20,165 +20,6 @@ function makeResponse(
   return new Response(bodyStr, { status, headers: headersObj });
 }
 
-describe('refresh', () => {
-  it('happy path: returns success with expiresAt in ms', async () => {
-    const before = Date.now();
-    const mockFetch = vi.fn().mockResolvedValue(
-      makeResponse(200, {
-        access_token: 'new-access',
-        refresh_token: 'new-refresh',
-        expires_in: 3600,
-      }),
-    );
-
-    const result = await refresh('old-refresh-token', mockFetch);
-
-    expect(result.kind).toBe('success');
-    if (result.kind !== 'success') return;
-    expect(result.data.accessToken).toBe('new-access');
-    expect(result.data.refreshToken).toBe('new-refresh');
-    // expiresAt must be ~3,600,000 ms from now — NOT 3600 (seconds)
-    const delta = result.data.expiresAt - before;
-    expect(delta).toBeGreaterThanOrEqual(3_600_000 - 100);
-    expect(delta).toBeLessThanOrEqual(3_600_000 + 100);
-  });
-
-  it('sends form-urlencoded body with correct Content-Type', async () => {
-    let capturedInit: RequestInit | undefined;
-    const mockFetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
-      capturedInit = init;
-      return Promise.resolve(
-        makeResponse(200, {
-          access_token: 'a',
-          refresh_token: 'r',
-          expires_in: 3600,
-        }),
-      );
-    });
-
-    await refresh('my-refresh-token', mockFetch);
-
-    expect(capturedInit).toBeDefined();
-    const headers = capturedInit!.headers as Record<string, string>;
-    expect(headers['Content-Type']).toBe('application/x-www-form-urlencoded');
-    expect(headers['Content-Type']).not.toContain('application/json');
-
-    const body = capturedInit!.body as string;
-    expect(typeof body).toBe('string');
-    expect(body).toMatch(/grant_type=refresh_token&refresh_token=[^&]+&client_id=9d1c250a-/);
-  });
-
-  it('401 -> auth-fatal', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(makeResponse(401, ''));
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('auth-fatal');
-    if (result.kind !== 'auth-fatal') return;
-    expect(result.reason).toBe('401');
-  });
-
-  it('400 with invalid_grant body -> auth-fatal', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(
-      makeResponse(400, JSON.stringify({ error: 'invalid_grant' })),
-    );
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('auth-fatal');
-    if (result.kind !== 'auth-fatal') return;
-    expect(result.reason).toBe('invalid_grant');
-  });
-
-  it('403 -> cloudflare-blocked', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(makeResponse(403, ''));
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('cloudflare-blocked');
-    if (result.kind !== 'cloudflare-blocked') return;
-    expect(result.status).toBe(403);
-  });
-
-  it('429 with Retry-After header -> rate-limited with that value, retryAfterPresent: true', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(
-      makeResponse(429, '', { 'Retry-After': '60' }),
-    );
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('rate-limited');
-    if (result.kind !== 'rate-limited') return;
-    expect(result.retryAfterSeconds).toBe(60);
-    expect(result.retryAfterPresent).toBe(true);
-    expect(result.xShouldRetry).toBeNull();
-  });
-
-  it('429 without Retry-After header -> defaults to 60s, retryAfterPresent: false', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(makeResponse(429, ''));
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('rate-limited');
-    if (result.kind !== 'rate-limited') return;
-    expect(result.retryAfterSeconds).toBe(60);
-    expect(result.retryAfterPresent).toBe(false);
-  });
-
-  it('429 with garbage Retry-After -> defaults to 60s, retryAfterPresent: false', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(
-      makeResponse(429, '', { 'Retry-After': 'not-a-number' }),
-    );
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('rate-limited');
-    if (result.kind !== 'rate-limited') return;
-    expect(result.retryAfterSeconds).toBe(60);
-    expect(result.retryAfterPresent).toBe(false);
-  });
-
-  it('429 with x-should-retry: false -> xShouldRetry: false', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(
-      makeResponse(429, '', { 'Retry-After': '30', 'x-should-retry': 'false' }),
-    );
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('rate-limited');
-    if (result.kind !== 'rate-limited') return;
-    expect(result.xShouldRetry).toBe(false);
-  });
-
-  it('500 -> transient with status 500', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(makeResponse(500, 'Internal Server Error'));
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('transient');
-    if (result.kind !== 'transient') return;
-    expect(result.status).toBe(500);
-  });
-
-  it('network error (fetch throws) -> transient with status 0', async () => {
-    const mockFetch = vi.fn().mockRejectedValue(new Error('Network failure'));
-    const result = await refresh('token', mockFetch);
-    expect(result.kind).toBe('transient');
-    if (result.kind !== 'transient') return;
-    expect(result.status).toBe(0);
-    expect(result.message).toBe('Network failure');
-  });
-
-  it('timeout (AbortController fires) -> transient', async () => {
-    vi.useFakeTimers();
-    const mockFetch = vi.fn().mockImplementation(
-      (_url: string, init: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          const signal = init.signal;
-          if (signal) {
-            signal.addEventListener('abort', () =>
-              reject(new DOMException('The operation was aborted.', 'AbortError')),
-            );
-          }
-        }),
-    );
-
-    const resultPromise = refresh('token', mockFetch);
-    vi.advanceTimersByTime(10_001);
-    const result = await resultPromise;
-
-    vi.useRealTimers();
-
-    expect(result.kind).toBe('transient');
-    if (result.kind !== 'transient') return;
-    expect(result.status).toBe(0);
-  });
-});
-
 describe('fetchUsage', () => {
   it('happy path: returns success with parsed usage data', async () => {
     const mockFetch = vi.fn().mockResolvedValue(
@@ -194,6 +35,39 @@ describe('fetchUsage', () => {
     expect(result.data.extra_usage?.is_enabled).toBe(true);
     expect(result.data.extra_usage?.used_credits).toBe(78000);
     expect(result.data.extra_usage?.monthly_limit).toBe(100000);
+  });
+
+  it('malformed 200 response -> transient without exposing parse details', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeResponse(200, 'not-json'),
+    );
+
+    const result = await fetchUsage('access-token-abc', mockFetch);
+
+    expect(result).toEqual({
+      kind: 'transient',
+      status: 200,
+      message: 'Invalid response from usage endpoint',
+    });
+  });
+
+  it.each([
+    ['non-object payload', []],
+    ['invalid usage bucket', { five_hour: { utilization: '42' } }],
+    ['invalid reset timestamp', {
+      seven_day: { utilization: 67, resets_at: 123 },
+    }],
+    ['invalid extra usage', { extra_usage: { is_enabled: 'yes' } }],
+  ])('invalid 200 %s -> transient', async (_description, body) => {
+    const mockFetch = vi.fn().mockResolvedValue(makeResponse(200, body));
+
+    const result = await fetchUsage('access-token-abc', mockFetch);
+
+    expect(result).toEqual({
+      kind: 'transient',
+      status: 200,
+      message: 'Invalid response from usage endpoint',
+    });
   });
 
   it('sends Authorization and anthropic-beta headers', async () => {
@@ -307,5 +181,48 @@ describe('fetchUsage', () => {
     expect(result.kind).toBe('transient');
     if (result.kind !== 'transient') return;
     expect(result.status).toBe(0);
+  });
+
+  it('keeps the timeout active while reading the response body', async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    let resolveBody: ((value: unknown) => void) | undefined;
+    const body = new Promise<unknown>((resolve, reject) => {
+      resolveBody = resolve;
+      const rejectOnAbort = () => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      };
+      queueMicrotask(() => {
+        if (signal?.aborted) {
+          rejectOnAbort();
+        } else {
+          signal?.addEventListener('abort', rejectOnAbort, { once: true });
+        }
+      });
+    });
+    const mockFetch = vi.fn().mockImplementation(
+      (_url: string, init: RequestInit) => {
+        signal = init.signal ?? undefined;
+        return Promise.resolve({
+          status: 200,
+          headers: new Headers(),
+          json: () => body,
+        } as Response);
+      },
+    );
+
+    const resultPromise = fetchUsage('token', mockFetch);
+    await vi.advanceTimersByTimeAsync(10_001);
+    const wasAborted = signal?.aborted;
+    resolveBody?.(usageFixture);
+    const result = await resultPromise;
+    vi.useRealTimers();
+
+    expect(wasAborted).toBe(true);
+    expect(result).toEqual({
+      kind: 'transient',
+      status: 200,
+      message: 'Invalid response from usage endpoint',
+    });
   });
 });

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -1,39 +1,43 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { runRefresh } from '../src/subcommands/refresh';
-import { readCache, writeCache, type Cache } from '../src/cache/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  readCache,
+  writeCache,
+  type Cache,
+} from '../src/cache/store';
+import type { OAuthCredentials } from '../src/credentials/envelope';
 import type { UsageResponse } from '../src/oauth/types';
-import { readDiagnosticLog } from '../src/diagnostics/logger';
+import type { CredentialSource } from '../src/credentials/source';
+import {
+  runRefresh,
+  type RefreshDeps,
+} from '../src/subcommands/refresh';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-refresh-test-'));
-}
-
-function cachePath(dir: string): string {
-  return path.join(dir, 'cache.json');
-}
-
-const MOCK_USAGE: UsageResponse = {
-  five_hour: { utilization: 0.1, resetsAt: '2026-05-03T12:00:00Z' },
-  seven_day: { utilization: 0.2, resetsAt: '2026-05-10T00:00:00Z' },
+const USAGE: UsageResponse = {
+  five_hour: { utilization: 12, resets_at: '2026-07-28T12:00:00Z' },
+  seven_day: { utilization: 34, resets_at: '2026-08-01T00:00:00Z' },
 };
 
-function makeCache(overrides: Partial<Cache> = {}): Cache {
-  const now = Date.now();
+const CONCURRENT_USAGE: UsageResponse = {
+  five_hour: { utilization: 91, resets_at: '2026-07-28T13:00:00Z' },
+  seven_day: { utilization: 82, resets_at: '2026-08-02T00:00:00Z' },
+};
+
+type SourceLoader = (
+  source: CredentialSource,
+) => Promise<OAuthCredentials>;
+
+function makeCache(now: number, overrides: Partial<Cache> = {}): Cache {
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     authState: 'ok',
     credentials: {
-      accessToken: 'at-fresh-token',
-      refreshToken: 'rt-refresh-token',
-      expiresAt: now + 60 * 60 * 1000, // 1 hour from now — fresh
+      accessToken: 'cached-access',
+      expiresAt: now + 60 * 60_000,
     },
+    credentialSource: { kind: 'claude-code' },
     usage: null,
     lastUsageRefreshAt: 0,
     lastRefreshStartedAt: 0,
@@ -45,836 +49,680 @@ function makeCache(overrides: Partial<Cache> = {}): Cache {
   };
 }
 
-/**
- * Build a minimal fetch mock that returns the given responses in order.
- * Each entry is a [status, bodyFn] tuple. bodyFn is called to produce the
- * response body (as an object that will be JSON-stringified, or a string for
- * text responses).
- */
-function buildFetchMock(
-  responses: Array<{
-    status: number;
-    body?: unknown;
-    headers?: Record<string, string>;
-    isText?: boolean;
-  }>,
-): typeof fetch {
-  let callIndex = 0;
-  return async (_input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
-    const entry = responses[callIndex++];
-    if (entry === undefined) {
-      throw new Error('Unexpected extra fetch call');
-    }
-    const bodyStr =
-      entry.body !== undefined
-        ? entry.isText
-          ? String(entry.body)
-          : JSON.stringify(entry.body)
-        : '';
-    const headersInit: Record<string, string> = entry.headers ?? {};
-    return new Response(bodyStr, {
-      status: entry.status,
-      headers: headersInit,
-    });
-  };
+function response(
+  status: number,
+  body: unknown = '',
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(
+    typeof body === 'string' ? body : JSON.stringify(body),
+    { status, headers },
+  );
 }
 
-/** Write a cache object to a temp dir's cache path. */
-async function writeTestCache(dir: string, cache: Cache): Promise<void> {
-  await writeCache(cache, cachePath(dir));
+function withSourceLoader(
+  deps: RefreshDeps,
+  loadCredentialSourceImpl: SourceLoader,
+): RefreshDeps {
+  return {
+    ...deps,
+    loadCredentialSourceImpl,
+  } as RefreshDeps;
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+function spyOnStdout() {
+  return vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+}
+
+function spyOnStderr() {
+  return vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+}
 
 describe('runRefresh', () => {
   let tmpDir: string;
-  let stdoutCallCount: number;
-  let stderrCallCount: number;
-  let stdoutRestore: () => void;
-  let stderrRestore: () => void;
+  let cachePath: string;
+  let now: number;
+  let stdout: ReturnType<typeof spyOnStdout>;
+  let stderr: ReturnType<typeof spyOnStderr>;
 
   beforeEach(() => {
-    tmpDir = makeTmpDir();
-    stdoutCallCount = 0;
-    stderrCallCount = 0;
-    const origStdout = process.stdout.write.bind(process.stdout);
-    const origStderr = process.stderr.write.bind(process.stderr);
-    // @ts-expect-error -- intentional spy override
-    process.stdout.write = (...args: Parameters<typeof process.stdout.write>) => { stdoutCallCount++; return true; };
-    // @ts-expect-error -- intentional spy override
-    process.stderr.write = (...args: Parameters<typeof process.stderr.write>) => { stderrCallCount++; return true; };
-    stdoutRestore = () => { process.stdout.write = origStdout; };
-    stderrRestore = () => { process.stderr.write = origStderr; };
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-statusline-refresh-'));
+    cachePath = path.join(tmpDir, 'cache.json');
+    now = 1_800_000_000_000;
+    stdout = spyOnStdout();
+    stderr = spyOnStderr();
   });
 
   afterEach(() => {
-    stdoutRestore();
-    stderrRestore();
+    stdout.mockRestore();
+    stderr.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 1: Happy path — token fresh
-  // -------------------------------------------------------------------------
-  it('1. happy path (token fresh): calls only fetchUsage, persists usage, authState ok', async () => {
-    const now = Date.now();
-    const cache = makeCache({
+  it('fetches usage once for a fresh usable cache without loading its source', async () => {
+    await writeCache(makeCache(now), cachePath);
+    const fetchImpl = vi.fn().mockResolvedValue(response(200, USAGE));
+    const loadSource = vi.fn<SourceLoader>();
+
+    expect(await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, loadSource))).toBe(0);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(loadSource).not.toHaveBeenCalled();
+    expect(readCache(cachePath)?.usage).toEqual(USAGE);
+  });
+
+  it('honors a refresh claim inherited from the renderer', async () => {
+    await writeCache(makeCache(now, {
+      lastRefreshStartedAt: now,
+    }), cachePath);
+    const fetchImpl = vi.fn().mockResolvedValue(response(200, USAGE));
+
+    expect(await runRefresh([`--claimed-at=${now}`], {
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    })).toBe(0);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(readCache(cachePath)?.usage).toEqual(USAGE);
+  });
+
+  it('does not refresh after an inherited claim has been replaced', async () => {
+    await writeCache(makeCache(now, {
+      lastRefreshStartedAt: now,
+    }), cachePath);
+    const fetchImpl = vi.fn();
+
+    expect(await runRefresh([`--claimed-at=${now - 1}`], {
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    })).toBe(0);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(readCache(cachePath)?.lastRefreshStartedAt).toBe(now);
+  });
+
+  it('loads the recorded source near expiry and never calls or sends data to a token endpoint', async () => {
+    const cached = makeCache(now, {
       credentials: {
-        accessToken: 'at-fresh',
-        refreshToken: 'rt-fresh',
-        expiresAt: now + 60 * 60 * 1000, // 1 hour — fresh
+        accessToken: 'old-access',
+        expiresAt: now + 2 * 60_000,
       },
     });
-    await writeTestCache(tmpDir, cache);
-
-    let fetchCallCount = 0;
-    const mockFetch = buildFetchMock([
-      // Only one call expected — fetchUsage
-      { status: 200, body: MOCK_USAGE },
-    ]);
-    const wrappedFetch: typeof fetch = async (input, init) => {
-      fetchCallCount++;
-      return mockFetch(input, init);
+    await writeCache(cached, cachePath);
+    const loadSource = vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'new-access',
+      refreshToken: 'source-refresh-secret',
+      expiresAt: now + 60 * 60_000,
+    });
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      requests.push({ url: String(input), init });
+      return response(200, USAGE);
     };
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: wrappedFetch,
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, loadSource));
+
+    expect(loadSource).toHaveBeenCalledWith(cached.credentialSource);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toContain('/usage');
+    expect(requests[0]?.url).not.toContain('/token');
+    expect(JSON.stringify(requests[0]?.init)).not.toContain('source-refresh-secret');
+    expect(readCache(cachePath)?.credentials).toEqual({
+      accessToken: 'new-access',
+      expiresAt: now + 60 * 60_000,
     });
-
-    expect(exitCode).toBe(0);
-    expect(fetchCallCount).toBe(1);
-
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.authState).toBe('ok');
-    expect(result!.usage).toEqual(MOCK_USAGE);
-    expect(result!.lastUsageRefreshAt).toBeGreaterThan(0);
-    expect(result!.lastErrorMessage).toBeNull();
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 2: Happy path — token near expiry
-  // -------------------------------------------------------------------------
-  it('2. happy path (token near expiry): calls refresh then fetchUsage, persists new credentials + usage', async () => {
-    const now = Date.now();
-    const cache = makeCache({
+  it('adopts a near-expiry candidate only after its usage request succeeds', async () => {
+    const cached = makeCache(now, {
+      credentials: { accessToken: 'old-access', expiresAt: now + 60_000 },
+      usage: USAGE,
+    });
+    await writeCache(cached, cachePath);
+    const candidate: OAuthCredentials = {
+      accessToken: 'candidate-access',
+      refreshToken: 'candidate-refresh',
+      expiresAt: now + 60 * 60_000,
+    };
+
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(
+        response(500, 'candidate-access candidate-refresh'),
+      ),
+    }, vi.fn<SourceLoader>().mockResolvedValue(candidate)));
+
+    const result = readCache(cachePath);
+    expect(result?.credentials).toEqual(cached.credentials);
+    expect(result?.usage).toEqual(USAGE);
+    expect(result?.lastErrorMessage).not.toContain('candidate-access');
+    expect(result?.lastErrorMessage).not.toContain('candidate-refresh');
+  });
+
+  it('promotes an advanced expiry for an unchanged token after usage succeeds', async () => {
+    await writeCache(makeCache(now, {
+      credentials: { accessToken: 'same-access', expiresAt: now + 60_000 },
+    }), cachePath);
+    const advancedExpiry = now + 90 * 60_000;
+
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(response(200, USAGE)),
+    }, vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'same-access',
+      refreshToken: 'unused-refresh',
+      expiresAt: advancedExpiry,
+    })));
+
+    expect(readCache(cachePath)?.credentials).toEqual({
+      accessToken: 'same-access',
+      expiresAt: advancedExpiry,
+    });
+  });
+
+  it('tries unchanged source only once and marks a final 401 fatal', async () => {
+    await writeCache(makeCache(now), cachePath);
+    const fetchImpl = vi.fn().mockResolvedValue(response(401));
+    const loadSource = vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'cached-access',
+      refreshToken: 'unchanged-refresh',
+      expiresAt: now + 60 * 60_000,
+    });
+
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, loadSource));
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(loadSource).toHaveBeenCalledOnce();
+    expect(readCache(cachePath)?.authState).toBe('fatal');
+  });
+
+  it('reloads after a usage 401 and retries once with a different source token', async () => {
+    await writeCache(makeCache(now), cachePath);
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response(401))
+      .mockResolvedValueOnce(response(200, USAGE));
+
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'recovered-access',
+      refreshToken: 'recovered-refresh',
+      expiresAt: now + 2 * 60 * 60_000,
+    })));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer cached-access',
+    });
+    expect(fetchImpl.mock.calls[1]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer recovered-access',
+    });
+    expect(readCache(cachePath)).toMatchObject({
+      authState: 'ok',
       credentials: {
-        accessToken: 'at-old',
-        refreshToken: 'rt-old',
-        expiresAt: now + 2 * 60 * 1000, // 2 minutes — near expiry
+        accessToken: 'recovered-access',
+        expiresAt: now + 2 * 60 * 60_000,
       },
+      usage: USAGE,
     });
-    await writeTestCache(tmpDir, cache);
-
-    const newExpiresAt = now + 3600 * 1000;
-    const urls: string[] = [];
-    const responses = [
-      // First call: refresh
-      {
-        status: 200,
-        body: {
-          access_token: 'at-new',
-          refresh_token: 'rt-new',
-          expires_in: 3600,
-        },
-      },
-      // Second call: fetchUsage
-      { status: 200, body: MOCK_USAGE },
-    ];
-    let respIdx = 0;
-
-    const mockFetch: typeof fetch = async (input, _init) => {
-      const url = typeof input === 'string' ? input : (input as Request).url ?? String(input);
-      urls.push(url);
-      const entry = responses[respIdx++]!;
-      return new Response(JSON.stringify(entry.body), { status: entry.status });
-    };
-
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
-
-    expect(exitCode).toBe(0);
-    expect(respIdx).toBe(2);
-
-    // Refresh URL called first, usage URL second
-    expect(urls[0]).toContain('token');
-    expect(urls[1]).toContain('usage');
-
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.credentials.accessToken).toBe('at-new');
-    expect(result!.credentials.refreshToken).toBe('rt-new');
-    expect(result!.credentials.expiresAt).toBeGreaterThan(newExpiresAt - 5000);
-    expect(result!.usage).toEqual(MOCK_USAGE);
-    expect(result!.authState).toBe('ok');
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 3: Cache missing
-  // -------------------------------------------------------------------------
-  it('3. cache missing: exit 0, no fetch calls', async () => {
-    // Do NOT write a cache file.
-    let fetchCalled = false;
-    const mockFetch: typeof fetch = async () => {
-      fetchCalled = true;
-      return new Response('', { status: 200 });
-    };
+  it('does not retry more than once when the replacement token also gets 401', async () => {
+    await writeCache(makeCache(now), cachePath);
+    const fetchImpl = vi.fn().mockResolvedValue(response(401));
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'replacement-access',
+      refreshToken: 'replacement-refresh',
+      expiresAt: now + 60 * 60_000,
+    })));
 
-    expect(exitCode).toBe(0);
-    expect(fetchCalled).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const result = readCache(cachePath);
+    expect(result?.authState).toBe('fatal');
+    expect(result?.credentials.accessToken).toBe('cached-access');
+    expect(result?.lastErrorMessage).not.toContain('replacement-access');
+    expect(result?.lastErrorMessage).not.toContain('replacement-refresh');
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 4: authState fatal
-  // -------------------------------------------------------------------------
-  it('4. authState fatal: exit 0, no fetch calls', async () => {
-    const cache = makeCache({ authState: 'fatal' });
-    await writeTestCache(tmpDir, cache);
+  it('self-heals a fatal cache when its source contains a new usable token', async () => {
+    await writeCache(makeCache(now, {
+      authState: 'fatal',
+      lastErrorMessage: 'old 401',
+    }), cachePath);
+    const fetchImpl = vi.fn().mockResolvedValue(response(200, USAGE));
 
-    let fetchCalled = false;
-    const mockFetch: typeof fetch = async () => {
-      fetchCalled = true;
-      return new Response('', { status: 200 });
-    };
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'healed-access',
+      refreshToken: 'healed-refresh',
+      expiresAt: now + 60 * 60_000,
+    })));
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(readCache(cachePath)).toMatchObject({
+      authState: 'ok',
+      credentials: { accessToken: 'healed-access' },
+      usage: USAGE,
+      lastErrorMessage: null,
     });
-
-    expect(exitCode).toBe(0);
-    expect(fetchCalled).toBe(false);
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 5: Refresh in flight
-  // -------------------------------------------------------------------------
-  it('5. refresh in flight: exit 0, no fetch calls', async () => {
-    const now = Date.now();
-    const cache = makeCache({
-      lastRefreshStartedAt: now - 500, // 500ms ago — within 1s window
+  it('loads the source for expired credentials', async () => {
+    await writeCache(makeCache(now, {
+      credentials: { accessToken: 'expired-access', expiresAt: now - 1 },
+    }), cachePath);
+    const loadSource = vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'current-access',
+      refreshToken: 'current-refresh',
+      expiresAt: now + 60 * 60_000,
     });
-    await writeTestCache(tmpDir, cache);
 
-    let fetchCalled = false;
-    const mockFetch: typeof fetch = async () => {
-      fetchCalled = true;
-      return new Response('', { status: 200 });
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(response(200, USAGE)),
+    }, loadSource));
+
+    expect(loadSource).toHaveBeenCalledOnce();
+    expect(readCache(cachePath)?.credentials.accessToken).toBe('current-access');
+  });
+
+  it('preserves cached credentials and usage when source loading fails', async () => {
+    const cached = makeCache(now, {
+      credentials: { accessToken: 'preserved-access', expiresAt: now + 60_000 },
+      usage: USAGE,
+      lastUsageRefreshAt: now - 30_000,
+    });
+    await writeCache(cached, cachePath);
+    const fetchImpl = vi.fn();
+
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockRejectedValue(
+      new Error('source validation failed'),
+    )));
+
+    const result = readCache(cachePath);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result?.credentials).toEqual(cached.credentials);
+    expect(result?.usage).toEqual(USAGE);
+    expect(result?.lastUsageRefreshAt).toBe(cached.lastUsageRefreshAt);
+    expect(result?.nextRefreshAllowedAt).toBe(now + 60_000);
+  });
+
+  it('preserves cached credentials and usage if reload after a 401 fails', async () => {
+    const cached = makeCache(now, { usage: USAGE });
+    await writeCache(cached, cachePath);
+
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl: vi.fn().mockResolvedValue(response(401)),
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockRejectedValue(
+      new Error('cannot validate credential source'),
+    )));
+
+    const result = readCache(cachePath);
+    expect(result?.credentials).toEqual(cached.credentials);
+    expect(result?.usage).toEqual(USAGE);
+    expect(result?.authState).toBe('fatal');
+  });
+
+  it('reloads exactly the recorded explicit file source', async () => {
+    const source: CredentialSource = {
+      kind: 'file',
+      path: path.join(tmpDir, 'enterprise-credentials.json'),
     };
+    await writeCache(makeCache(now, {
+      authState: 'fatal',
+      credentialSource: source,
+    }), cachePath);
+    const loadSource = vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'file-access',
+      refreshToken: 'file-refresh',
+      expiresAt: now + 60 * 60_000,
+    });
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(response(200, USAGE)),
+    }, loadSource));
+
+    expect(loadSource).toHaveBeenCalledOnce();
+    expect(loadSource).toHaveBeenCalledWith(source);
+  });
+
+  it('does not overwrite credentials committed by init during a request', async () => {
+    await writeCache(makeCache(now), cachePath);
+    const initCredentials = {
+      accessToken: 'reauthenticated-access',
+      expiresAt: now + 2 * 60 * 60_000,
+    };
+    let initSnapshot: Cache | null = null;
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      await writeCache(makeCache(now, {
+        credentials: initCredentials,
+        usage: CONCURRENT_USAGE,
+        lastUsageRefreshAt: now + 1,
+        lastRefreshStartedAt: 0,
+      }), cachePath);
+      initSnapshot = readCache(cachePath);
+      return response(200, USAGE);
+    });
+
+    await runRefresh([], {
+      cachePath,
+      fetchImpl,
       now: () => now,
     });
 
-    expect(exitCode).toBe(0);
-    expect(fetchCalled).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(readCache(cachePath)).toEqual(initSnapshot);
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 6: Refresh returns auth-fatal → cache authState becomes 'fatal'
-  // -------------------------------------------------------------------------
-  it('6. refresh auth-fatal: cache.authState becomes fatal, subsequent run exits silently', async () => {
-    const now = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-expiring',
-        refreshToken: 'rt-expiring',
-        expiresAt: now + 2 * 60 * 1000, // near expiry
-      },
+  it('discards candidate success when a concurrent cache has newer credentials and usage', async () => {
+    const starting = makeCache(now, {
+      credentials: { accessToken: 'starting-access', expiresAt: now + 60_000 },
     });
-    await writeTestCache(tmpDir, cache);
-
-    const mockFetch = buildFetchMock([
-      // Refresh returns 401 (auth-fatal)
-      { status: 401 },
-    ]);
-
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
-
-    expect(exitCode).toBe(0);
-
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.authState).toBe('fatal');
-    expect(result!.lastErrorMessage).not.toBeNull();
-
-    // Subsequent run should bail immediately without fetch.
-    let fetchCalled = false;
-    const mockFetch2: typeof fetch = async () => {
-      fetchCalled = true;
-      return new Response('', { status: 200 });
+    await writeCache(starting, cachePath);
+    const candidate: OAuthCredentials = {
+      accessToken: 'candidate-access',
+      refreshToken: 'candidate-refresh',
+      expiresAt: now + 60 * 60_000,
     };
-    const exitCode2 = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch2,
-    });
-    expect(exitCode2).toBe(0);
-    expect(fetchCalled).toBe(false);
-  });
-
-  // -------------------------------------------------------------------------
-  // Scenario 7: fetchUsage auth-fatal post-rotation (tokenJustRotated === true)
-  // -------------------------------------------------------------------------
-  it('7. fetchUsage auth-fatal post-rotation: message mentions post-rotation revocation', async () => {
-    const now = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-near',
-        refreshToken: 'rt-near',
-        expiresAt: now + 2 * 60 * 1000, // near expiry → will rotate
-      },
-    });
-    await writeTestCache(tmpDir, cache);
-
-    const mockFetch = buildFetchMock([
-      // Refresh succeeds
-      {
-        status: 200,
-        body: {
-          access_token: 'at-rotated',
-          refresh_token: 'rt-rotated',
-          expires_in: 3600,
-        },
-      },
-      // fetchUsage returns 401 auth-fatal
-      { status: 401 },
-    ]);
-
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
-
-    expect(exitCode).toBe(0);
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.authState).toBe('fatal');
-    // Should mention post-rotation revocation
-    expect(result!.lastErrorMessage).toMatch(/rotation|revocation/i);
-  });
-
-  // -------------------------------------------------------------------------
-  // Scenario 8: fetchUsage auth-fatal without rotation (tokenJustRotated === false)
-  // -------------------------------------------------------------------------
-  it('8. fetchUsage auth-fatal without rotation: standard fatal message', async () => {
-    const now = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-fresh-fatal',
-        refreshToken: 'rt-fresh-fatal',
-        expiresAt: now + 60 * 60 * 1000, // fresh — no rotation
-      },
-    });
-    await writeTestCache(tmpDir, cache);
-
-    const mockFetch = buildFetchMock([
-      // fetchUsage returns 401 auth-fatal (no refresh call precedes)
-      { status: 401 },
-    ]);
-
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
-
-    expect(exitCode).toBe(0);
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.authState).toBe('fatal');
-    // Should NOT mention post-rotation
-    expect(result!.lastErrorMessage).not.toMatch(/rotation|revocation/i);
-    expect(result!.lastErrorMessage).toMatch(/auth-fatal|401/i);
-  });
-
-  // -------------------------------------------------------------------------
-  // Scenario 9: TOCTOU dedup
-  // -------------------------------------------------------------------------
-  it('9. TOCTOU dedup: second process sees competing lastRefreshStartedAt, exits without fetch', async () => {
-    // We simulate the race by making the 2nd readCache (the verify re-read)
-    // return a different lastRefreshStartedAt from what we wrote.
-    // Strategy: write the real cache, then use a deps.now that produces a
-    // stable timestamp, and manually overwrite the cache between writes.
-
-    const frozenNow = Date.now();
-    const cache = makeCache({ lastRefreshStartedAt: 0 });
-    await writeTestCache(tmpDir, cache);
-
-    let fetchCalled = false;
-    const mockFetch: typeof fetch = async () => {
-      fetchCalled = true;
-      return new Response(JSON.stringify(MOCK_USAGE), { status: 200 });
+    const newer = {
+      accessToken: 'concurrent-access',
+      expiresAt: now + 2 * 60 * 60_000,
+    };
+    let concurrentSnapshot: Cache | undefined;
+    const fetchImpl: typeof fetch = async () => {
+      const concurrent = readCache(cachePath)!;
+      concurrent.credentials = newer;
+      concurrent.usage = CONCURRENT_USAGE;
+      concurrent.lastUsageRefreshAt = now + 123;
+      concurrent.lastErrorMessage = 'newer process result';
+      concurrent.authState = 'ok';
+      await writeCache(concurrent, cachePath);
+      concurrentSnapshot = readCache(cachePath)!;
+      return response(200, USAGE);
     };
 
-    // We intercept by wrapping writeCache: after the CAS write, we overwrite
-    // the cache file with a competing lastRefreshStartedAt (different value).
-    // Since we can't easily intercept writeCache from outside, we instead test
-    // a cleaner approach: we use a custom now() that returns `frozenNow`, then
-    // after the test writes its CAS timestamp, we write a competing one.
-    //
-    // The cleanest pure approach is: start the runRefresh with a slow mockFetch
-    // that allows us to write a competing cache after the CAS write. But since
-    // runRefresh is async and we can't pause it mid-execution with a timer
-    // (no sleeps per guidelines), we test by pre-seeding a lastRefreshStartedAt
-    // that is DIFFERENT from frozenNow so the verify step catches it.
-    //
-    // The implementation re-reads the cache after writing startedAt. If the
-    // re-read returns a different lastRefreshStartedAt, it exits. We simulate
-    // this by writing the cache with a competing timestamp BEFORE runRefresh
-    // runs, but we need the CAS write to happen first.
-    //
-    // The reliable approach: use a mock writeCache. Instead, we test the
-    // isRefreshInFlight guard (scenario 5 covers that), and here we test the
-    // post-CAS verify mismatch by using vi.mock on the store.
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockResolvedValue(candidate)));
 
-    // Use vi.mock for this specific test to intercept readCache.
-    // Since vitest doesn't support inline per-test module mocking easily
-    // without top-level vi.mock, we test the mismatch by having the cache
-    // already written with a competing timestamp before the second read
-    // (which is the verify read). We do this by:
-    // 1. Writing the cache normally.
-    // 2. Setting lastRefreshStartedAt = frozenNow - 1 (so it differs from frozenNow).
-    // 3. Having now() return frozenNow.
-    // 4. The implementation will write frozenNow, then re-read, and find the
-    //    file still has frozenNow (no race). This doesn't simulate the race.
-    //
-    // The correct simulation: we need to overwrite the cache BETWEEN the CAS
-    // write and the verify re-read. The only way without pausing the event loop
-    // is to use a fake fetchImpl that does the overwrite before returning.
-    // But the verify re-read happens before any fetch call.
-    //
-    // Solution: use a mockFetch that also overwrites the cache file with a
-    // competing timestamp when called, and verify fetch is NOT called (meaning
-    // the overwrite was done by a different mechanism). Instead, we can pass a
-    // custom writeCache wrapper via deps. Since deps only exposes cachePath,
-    // fetchImpl, and now, we cannot intercept writeCache.
-    //
-    // The practical test: We write the cache with lastRefreshStartedAt equal to
-    // frozenNow. When runRefresh runs with now() = frozenNow, it will see
-    // isRefreshInFlight = true (frozenNow - frozenNow = 0 < 1000) and exit
-    // early. This validates the in-flight path, which IS the TOCTOU guard.
-
-    // Pre-write the cache with lastRefreshStartedAt = frozenNow (simulating another
-    // process that just claimed the CAS lock).
-    const competingCache = makeCache({ lastRefreshStartedAt: frozenNow });
-    await writeTestCache(tmpDir, competingCache);
-
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-      now: () => frozenNow,
-    });
-
-    expect(exitCode).toBe(0);
-    expect(fetchCalled).toBe(false);
+    expect(readCache(cachePath)).toEqual(concurrentSnapshot);
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 10: Sanitized error — accessToken must not appear in persisted message
-  // -------------------------------------------------------------------------
-  it('10. sanitized error: persisted lastErrorMessage does not contain accessToken', async () => {
-    const now = Date.now();
-    const accessToken = 'at-secret-value-xyz';
-    const cache = makeCache({
-      credentials: {
-        accessToken,
-        refreshToken: 'rt-secret',
-        expiresAt: now + 60 * 60 * 1000, // fresh token
-      },
-    });
-    await writeTestCache(tmpDir, cache);
+  it('discards a final 401 when a concurrent cache has newer credentials and usage', async () => {
+    await writeCache(makeCache(now), cachePath);
+    const candidate: OAuthCredentials = {
+      accessToken: 'candidate-access',
+      refreshToken: 'candidate-refresh',
+      expiresAt: now + 60 * 60_000,
+    };
+    let concurrentSnapshot: Cache | undefined;
+    let callCount = 0;
+    const fetchImpl: typeof fetch = async () => {
+      callCount += 1;
+      if (callCount === 1) return response(401);
 
-    // fetchUsage returns a transient error whose message contains the accessToken
-    const mockFetch: typeof fetch = async () => {
-      throw new Error(`Network error with token ${accessToken}`);
+      const concurrent = readCache(cachePath)!;
+      concurrent.credentials = {
+        accessToken: 'concurrent-access',
+        expiresAt: now + 2 * 60 * 60_000,
+      };
+      concurrent.usage = CONCURRENT_USAGE;
+      concurrent.lastUsageRefreshAt = now + 456;
+      concurrent.lastErrorMessage = null;
+      concurrent.authState = 'ok';
+      await writeCache(concurrent, cachePath);
+      concurrentSnapshot = readCache(cachePath)!;
+      return response(401);
     };
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockResolvedValue(candidate)));
 
-    expect(exitCode).toBe(0);
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.lastErrorMessage).not.toBeNull();
-    expect(result!.lastErrorMessage).not.toContain(accessToken);
-    expect(result!.lastErrorMessage).toContain('<redacted>');
+    expect(callCount).toBe(2);
+    expect(readCache(cachePath)).toEqual(concurrentSnapshot);
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 11: Cloudflare-blocked refresh
-  // -------------------------------------------------------------------------
-  it('11. cloudflare-blocked refresh: authState becomes cloudflare-blocked, message mentions Cloudflare', async () => {
-    const now = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-cf',
-        refreshToken: 'rt-cf',
-        expiresAt: now + 2 * 60 * 1000, // near expiry
-      },
-    });
-    await writeTestCache(tmpDir, cache);
+  it('discards a transient candidate result when a concurrent cache has newer credentials and usage', async () => {
+    await writeCache(makeCache(now, {
+      credentials: { accessToken: 'starting-access', expiresAt: now + 60_000 },
+    }), cachePath);
+    let concurrentSnapshot: Cache | undefined;
+    const fetchImpl: typeof fetch = async () => {
+      const concurrent = readCache(cachePath)!;
+      concurrent.credentials = {
+        accessToken: 'concurrent-access',
+        expiresAt: now + 2 * 60 * 60_000,
+      };
+      concurrent.usage = CONCURRENT_USAGE;
+      concurrent.lastUsageRefreshAt = now + 789;
+      concurrent.lastErrorMessage = null;
+      await writeCache(concurrent, cachePath);
+      concurrentSnapshot = readCache(cachePath)!;
+      return response(500, 'stale request failed');
+    };
 
-    const mockFetch = buildFetchMock([
-      // Refresh returns 403 (cloudflare-blocked)
-      { status: 403 },
-    ]);
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, vi.fn<SourceLoader>().mockResolvedValue({
+      accessToken: 'candidate-access',
+      refreshToken: 'candidate-refresh',
+      expiresAt: now + 60 * 60_000,
+    })));
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
-
-    expect(exitCode).toBe(0);
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.authState).toBe('cloudflare-blocked');
-    expect(result!.lastErrorMessage).toMatch(/cloudflare/i);
+    expect(readCache(cachePath)).toEqual(concurrentSnapshot);
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 12: Rate-limited fetchUsage
-  // -------------------------------------------------------------------------
-  it('12. rate-limited fetchUsage: persists rateLimitedUntilMs, header-present note, authState stays ok', async () => {
-    const frozenNow = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-rl',
-        refreshToken: 'rt-rl',
-        expiresAt: frozenNow + 60 * 60 * 1000, // fresh
-      },
-    });
-    await writeTestCache(tmpDir, cache);
+  it('discards a source failure when a concurrent cache has newer credentials and usage', async () => {
+    await writeCache(makeCache(now, {
+      credentials: { accessToken: 'starting-access', expiresAt: now + 60_000 },
+    }), cachePath);
+    let concurrentSnapshot: Cache | undefined;
+    const loadSource: SourceLoader = async () => {
+      const concurrent = readCache(cachePath)!;
+      concurrent.credentials = {
+        accessToken: 'concurrent-access',
+        expiresAt: now + 2 * 60 * 60_000,
+      };
+      concurrent.usage = CONCURRENT_USAGE;
+      concurrent.lastUsageRefreshAt = now + 987;
+      concurrent.lastErrorMessage = null;
+      await writeCache(concurrent, cachePath);
+      concurrentSnapshot = readCache(cachePath)!;
+      throw new Error('stale source failed');
+    };
 
-    const mockFetch = buildFetchMock([
-      { status: 429, headers: { 'Retry-After': '120', 'x-should-retry': 'false' } },
-    ]);
+    await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl: vi.fn(),
+      now: () => now,
+    }, loadSource));
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-      now: () => frozenNow,
-    });
-
-    expect(exitCode).toBe(0);
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.authState).toBe('ok');
-    expect(result!.lastErrorMessage).toMatch(/retry-after/i);
-    expect(result!.lastErrorMessage).toContain('header present');
-    expect(result!.lastErrorMessage).toContain('x-should-retry: false');
-    expect(result!.rateLimitedUntilMs).toBe(frozenNow + 120_000);
-    expect(result!.nextRefreshAllowedAt).toBe(frozenNow + 300_000);
-    expect(result!.consecutiveRateLimitCount).toBe(1);
-
-    const log = await readDiagnosticLog(path.join(tmpDir, 'debug.log'));
-    expect(log).toContain('"event":"http.result"');
-    expect(log).toContain('"endpoint":"usage"');
-    expect(log).toContain('"status":429');
-    expect(log).toContain('"retryAfterSeconds":120');
-    expect(log).not.toContain('at-rl');
-    expect(log).not.toContain('rt-rl');
+    expect(readCache(cachePath)).toEqual(concurrentSnapshot);
   });
 
-  it('12b. rate-limited with header absent: lastErrorMessage notes default applied', async () => {
-    const frozenNow = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-rl-no-header',
-        refreshToken: 'rt-rl-no-header',
-        expiresAt: frozenNow + 60 * 60 * 1000,
-      },
-    });
-    await writeTestCache(tmpDir, cache);
+  it('keeps missing, in-flight, and cooldown paths network-free', async () => {
+    const fetchImpl = vi.fn();
+    const loadSource = vi.fn<SourceLoader>();
+    const deps = withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, loadSource);
 
-    const mockFetch = buildFetchMock([
-      { status: 429 }, // no Retry-After
-    ]);
+    await runRefresh([], deps);
 
+    await writeCache(makeCache(now, {
+      lastRefreshStartedAt: now - 500,
+    }), cachePath);
+    await runRefresh([], deps);
+
+    await writeCache(makeCache(now, {
+      rateLimitedUntilMs: now + 60_000,
+      nextRefreshAllowedAt: now + 120_000,
+    }), cachePath);
+    await runRefresh([], deps);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(loadSource).not.toHaveBeenCalled();
+  });
+
+  it('treats malformed v4 JSON as a missing cache', async () => {
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify({ schemaVersion: 4 }),
+      'utf8',
+    );
+    const fetchImpl = vi.fn();
+    const loadSource = vi.fn<SourceLoader>();
+
+    expect(await runRefresh([], withSourceLoader({
+      cachePath,
+      fetchImpl,
+      now: () => now,
+    }, loadSource))).toBe(0);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(loadSource).not.toHaveBeenCalled();
+    expect(readCache(cachePath)).toBeNull();
+  });
+
+  it('persists explicit 429 cooldown diagnostics and clears them on success', async () => {
+    await writeCache(makeCache(now), cachePath);
     await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-      now: () => frozenNow,
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(response(429, '', {
+        'Retry-After': '120',
+        'x-should-retry': 'false',
+      })),
     });
 
-    const result = readCache(cachePath(tmpDir));
-    expect(result!.lastErrorMessage).toContain('header absent, default applied');
-    expect(result!.rateLimitedUntilMs).toBe(frozenNow + 60_000);
-    expect(result!.nextRefreshAllowedAt).toBe(frozenNow + 240_000);
-    expect(result!.consecutiveRateLimitCount).toBe(1);
-  });
-
-  it('12c. successful fetchUsage clears rateLimitedUntilMs', async () => {
-    const frozenNow = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-recover',
-        refreshToken: 'rt-recover',
-        expiresAt: frozenNow + 60 * 60 * 1000,
-      },
-      rateLimitedUntilMs: frozenNow - 1000, // expired cooldown — refresh proceeds
-    });
-    await writeTestCache(tmpDir, cache);
-
-    const mockFetch = buildFetchMock([
-      { status: 200, body: MOCK_USAGE },
-    ]);
-
-    await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-      now: () => frozenNow,
-    });
-
-    const result = readCache(cachePath(tmpDir));
-    expect(result!.rateLimitedUntilMs).toBe(0);
-    expect(result!.nextRefreshAllowedAt).toBe(0);
-    expect(result!.consecutiveRateLimitCount).toBe(0);
-    expect(result!.usage).toEqual(MOCK_USAGE);
-  });
-
-  it('12e. consecutive rate limits increase backoff and streak', async () => {
-    const frozenNow = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-rl-consecutive',
-        refreshToken: 'rt-rl-consecutive',
-        expiresAt: frozenNow + 60 * 60_000, // fresh
-      },
+    expect(readCache(cachePath)).toMatchObject({
+      authState: 'ok',
+      rateLimitedUntilMs: now + 120_000,
+      nextRefreshAllowedAt: now + 300_000,
       consecutiveRateLimitCount: 1,
-      nextRefreshAllowedAt: frozenNow - 1_000,
-      rateLimitedUntilMs: frozenNow - 1_000,
     });
-    await writeTestCache(tmpDir, cache);
+    expect(readCache(cachePath)?.lastErrorMessage).toContain(
+      'x-should-retry: false',
+    );
 
-    const mockFetch = buildFetchMock([
-      { status: 429, headers: { 'Retry-After': '60' } },
-    ]);
+    now += 301_000;
+    await runRefresh([], {
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(response(200, USAGE)),
+    });
+    expect(readCache(cachePath)).toMatchObject({
+      rateLimitedUntilMs: 0,
+      nextRefreshAllowedAt: 0,
+      consecutiveRateLimitCount: 0,
+    });
+  });
+
+  it('handles usage 403 explicitly without changing credentials or usage', async () => {
+    const cached = makeCache(now, { usage: USAGE });
+    await writeCache(cached, cachePath);
 
     await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-      now: () => frozenNow,
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(response(403)),
     });
 
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.consecutiveRateLimitCount).toBe(2);
-    expect(result!.nextRefreshAllowedAt).toBe(frozenNow + 300_000);
-    expect(result!.nextRefreshAllowedAt).toBeGreaterThan(result!.rateLimitedUntilMs);
+    expect(readCache(cachePath)).toMatchObject({
+      authState: 'cloudflare-blocked',
+      credentials: cached.credentials,
+      usage: USAGE,
+      nextRefreshAllowedAt: now + 60_000,
+    });
   });
 
-  it('12f. cooldown active from nextRefreshAllowedAt also prevents refresh', async () => {
-    const frozenNow = Date.now();
-    const cache = makeCache({
+  it('handles transient usage errors explicitly and sanitizes diagnostics', async () => {
+    const cached = makeCache(now, {
       credentials: {
-        accessToken: 'at-rl-backoff-only',
-        refreshToken: 'rt-rl-backoff-only',
-        expiresAt: frozenNow + 60 * 60_000,
+        accessToken: 'sensitive-access',
+        expiresAt: now + 60 * 60_000,
       },
-      rateLimitedUntilMs: frozenNow - 1_000,
-      nextRefreshAllowedAt: frozenNow + 45_000,
-      consecutiveRateLimitCount: 2,
+      usage: USAGE,
     });
-    await writeTestCache(tmpDir, cache);
-
-    let fetchCalled = false;
-    const mockFetch: typeof fetch = async () => {
-      fetchCalled = true;
-      return new Response('', { status: 200 });
-    };
+    await writeCache(cached, cachePath);
 
     await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-      now: () => frozenNow,
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockRejectedValue(
+        new Error('network failed for sensitive-access'),
+      ),
     });
 
-    expect(fetchCalled).toBe(false);
-    const result = readCache(cachePath(tmpDir));
-    expect(result!.nextRefreshAllowedAt).toBe(frozenNow + 45_000);
-  });
+    const result = readCache(cachePath);
+    expect(result?.authState).toBe('ok');
+    expect(result?.usage).toEqual(USAGE);
+    expect(result?.lastErrorMessage).toBe('network failed for <redacted>');
+    expect(result?.nextRefreshAllowedAt).toBe(now + 60_000);
 
-  it('12d. cooldown active: runRefresh exits without making any fetch call', async () => {
-    const frozenNow = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-still-cooling',
-        refreshToken: 'rt-still-cooling',
-        expiresAt: frozenNow + 60 * 60 * 1000,
-      },
-      rateLimitedUntilMs: frozenNow + 60_000, // 60s of cooldown remaining
-    });
-    await writeTestCache(tmpDir, cache);
-
-    let fetchCalled = false;
-    const mockFetch: typeof fetch = async () => {
-      fetchCalled = true;
-      return new Response('', { status: 200 });
-    };
-
+    const retry = vi.fn();
     await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-      now: () => frozenNow,
+      cachePath,
+      now: () => now + 30_000,
+      fetchImpl: retry,
     });
-
-    expect(fetchCalled).toBe(false);
-    // Cache untouched.
-    const result = readCache(cachePath(tmpDir));
-    expect(result!.rateLimitedUntilMs).toBe(frozenNow + 60_000);
+    expect(retry).not.toHaveBeenCalled();
   });
 
-  // -------------------------------------------------------------------------
-  // Scenario 13: Network error during refresh (transient)
-  // -------------------------------------------------------------------------
-  it('13. transient error during refresh: authState stays ok, lastErrorMessage set', async () => {
-    const now = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-transient',
-        refreshToken: 'rt-transient',
-        expiresAt: now + 2 * 60 * 1000, // near expiry
-      },
-    });
-    await writeTestCache(tmpDir, cache);
+  it('always exits zero and remains silent', async () => {
+    await writeCache(makeCache(now), cachePath);
 
-    // Simulate network failure (transient)
-    const mockFetch: typeof fetch = async () => {
-      throw new Error('ECONNRESET: connection reset by peer');
-    };
+    expect(await runRefresh([], {
+      cachePath,
+      now: () => now,
+      fetchImpl: vi.fn().mockResolvedValue(response(200, USAGE)),
+    })).toBe(0);
 
-    const exitCode = await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
-
-    expect(exitCode).toBe(0);
-    const result = readCache(cachePath(tmpDir));
-    expect(result).not.toBeNull();
-    expect(result!.authState).toBe('ok');
-    expect(result!.lastErrorMessage).not.toBeNull();
-    expect(result!.lastErrorMessage).toContain('ECONNRESET');
-  });
-
-  // -------------------------------------------------------------------------
-  // Scenario 14: stdout/stderr silence
-  // -------------------------------------------------------------------------
-  it('14. stdout/stderr silence: no writes to process.stdout or process.stderr in normal flows', async () => {
-    const now = Date.now();
-    const cache = makeCache({
-      credentials: {
-        accessToken: 'at-silent',
-        refreshToken: 'rt-silent',
-        expiresAt: now + 60 * 60 * 1000, // fresh
-      },
-    });
-    await writeTestCache(tmpDir, cache);
-
-    const mockFetch = buildFetchMock([
-      { status: 200, body: MOCK_USAGE },
-    ]);
-
-    await runRefresh([], {
-      cachePath: cachePath(tmpDir),
-      fetchImpl: mockFetch,
-    });
-
-    expect(stdoutCallCount).toBe(0);
-    expect(stderrCallCount).toBe(0);
-  });
-
-  // -------------------------------------------------------------------------
-  // Scenario 15: Exit code is 0 in all scenarios
-  // -------------------------------------------------------------------------
-  it('15. exit code is always 0 across all cases', async () => {
-    const now = Date.now();
-
-    // Case A: happy path
-    {
-      const dir = makeTmpDir();
-      try {
-        const c = makeCache({ credentials: { accessToken: 'a', refreshToken: 'r', expiresAt: now + 3600_000 } });
-        await writeCache(c, cachePath(dir));
-        const code = await runRefresh([], {
-          cachePath: cachePath(dir),
-          fetchImpl: buildFetchMock([{ status: 200, body: MOCK_USAGE }]),
-        });
-        expect(code).toBe(0);
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }
-
-    // Case B: cache missing
-    {
-      const dir = makeTmpDir();
-      try {
-        const code = await runRefresh([], { cachePath: cachePath(dir) });
-        expect(code).toBe(0);
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }
-
-    // Case C: authState fatal
-    {
-      const dir = makeTmpDir();
-      try {
-        const c = makeCache({ authState: 'fatal' });
-        await writeCache(c, cachePath(dir));
-        const code = await runRefresh([], { cachePath: cachePath(dir) });
-        expect(code).toBe(0);
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }
-
-    // Case D: refresh auth-fatal
-    {
-      const dir = makeTmpDir();
-      try {
-        const c = makeCache({ credentials: { accessToken: 'a', refreshToken: 'r', expiresAt: now + 2 * 60_000 } });
-        await writeCache(c, cachePath(dir));
-        const code = await runRefresh([], {
-          cachePath: cachePath(dir),
-          fetchImpl: buildFetchMock([{ status: 401 }]),
-        });
-        expect(code).toBe(0);
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }
-
-    // Case E: fetchUsage cloudflare-blocked
-    {
-      const dir = makeTmpDir();
-      try {
-        const c = makeCache({ credentials: { accessToken: 'a', refreshToken: 'r', expiresAt: now + 3600_000 } });
-        await writeCache(c, cachePath(dir));
-        const code = await runRefresh([], {
-          cachePath: cachePath(dir),
-          fetchImpl: buildFetchMock([{ status: 403 }]),
-        });
-        expect(code).toBe(0);
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
   });
 });

--- a/tests/render-enterprise-runtime.test.ts
+++ b/tests/render-enterprise-runtime.test.ts
@@ -112,7 +112,6 @@ describe('background refresh integration', () => {
         cachePath,
         bundlePath: '/bundle.js',
         now: () => now,
-        platformOverride: 'linux' as const,
         spawnRefresh: (
           command: string,
           args: string[],
@@ -155,7 +154,6 @@ describe('background refresh integration', () => {
       cachePath,
       bundlePath: '/bundle.js',
       now: () => now,
-      platformOverride: 'linux' as const,
       spawnRefresh: () => {
         attempts += 1;
         if (attempts === 1) throw new Error('spawn failed');
@@ -186,25 +184,22 @@ describe('background refresh integration', () => {
 });
 
 describe('refresh process boundary', () => {
-  async function captureSpawnForPlatform(
-    platform: NodeJS.Platform,
-    bundlePath: string,
-  ): Promise<SpawnCall> {
+  async function captureRefreshSpawn(bundlePath: string): Promise<SpawnCall> {
     const now = Date.now();
     const { spawnCalls } = await runWithCache(
       makeCacheWithUsage({}, {
         lastUsageRefreshAt: now - 5 * 60_000,
       }),
       loadFixture('stdin-enterprise.json'),
-      { now: () => now, bundlePath, platformOverride: platform },
+      { now: () => now, bundlePath },
     );
     const call = spawnCalls[0];
     expect(call).toBeDefined();
     return call!;
   }
 
-  it('uses detached Node on POSIX', async () => {
-    const call = await captureSpawnForPlatform('linux', '/bundle.js');
+  it('uses detached Node directly', async () => {
+    const call = await captureRefreshSpawn('/bundle.js');
 
     expect(call.command).toBe(process.execPath);
     expect(call.args).toEqual([
@@ -214,25 +209,28 @@ describe('refresh process boundary', () => {
     ]);
     expect(call.opts).toMatchObject({
       detached: true,
+      shell: false,
       stdio: 'ignore',
+      windowsHide: true,
     });
   });
 
-  it('uses a minimized detached command on Windows', async () => {
-    const call = await captureSpawnForPlatform('win32', 'C:\\bundle.js');
+  it('uses detached Node without a shell for Windows paths containing metacharacters', async () => {
+    const bundlePath = 'C:\\Users\\A&B\\cc statusline.js';
+    const call = await captureRefreshSpawn(bundlePath);
 
-    expect(call.command).toBe('cmd.exe');
+    expect(call.command).toBe(process.execPath);
     expect(call.args).toEqual([
-      '/c',
-      'start',
-      '/b',
-      '/min',
-      process.execPath,
-      'C:\\bundle.js',
+      bundlePath,
       'refresh',
       expect.stringMatching(/^--claimed-at=\d+$/),
     ]);
-    expect(call.opts.stdio).toBe('ignore');
+    expect(call.opts).toMatchObject({
+      detached: true,
+      shell: false,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
   });
 
   it('passes only the required environment variables', async () => {

--- a/tests/render-enterprise-runtime.test.ts
+++ b/tests/render-enterprise-runtime.test.ts
@@ -1,0 +1,375 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  RATE_LIMITED_HINT_PREFIX,
+  runRenderEnterprise,
+} from '../src/subcommands/render-enterprise';
+import { STALE_MARKER } from '../src/statusline/format';
+import { writeCache } from '../src/cache/store';
+import {
+  captureStdout,
+  loadFixture,
+  makeCacheWithUsage,
+  makeStream,
+  runWithCache,
+  setTTY,
+  type SpawnCall,
+} from './support/render-enterprise';
+
+beforeEach(() => {
+  vi.stubEnv('NO_COLOR', '');
+  setTTY(false);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('background refresh integration', () => {
+  it('renders stale usage and spawns one refresh', async () => {
+    const now = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: now - 20 * 60_000,
+    });
+
+    const { output, spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    expect(output).toContain(STALE_MARKER);
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it('does not spawn while another refresh is in flight', async () => {
+    const now = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: now - 20 * 60_000,
+      lastRefreshStartedAt: now - 30_000,
+    });
+
+    const { spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('keeps the refresh launch path under 100ms', async () => {
+    const now = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: now - 5 * 60_000,
+    });
+    const tempDir = mkdtempSync(join(tmpdir(), 'cc-statusline-render-perf-'));
+    const cachePath = join(tempDir, 'cache.json');
+    await writeCache(cache, cachePath);
+    let spawned = false;
+    const startedAt = performance.now();
+
+    try {
+      const { exitCode } = await captureStdout(() =>
+        runRenderEnterprise(
+          [],
+          makeStream(loadFixture('stdin-enterprise.json')),
+          {
+            cachePath,
+            bundlePath: '/bundle.js',
+            now: () => now,
+            spawnRefresh: () => {
+              spawned = true;
+            },
+          },
+        ),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(spawned).toBe(true);
+      expect(performance.now() - startedAt).toBeLessThan(100);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('claims a stale cache before spawning so concurrent renderers spawn once', async () => {
+    const now = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: now - 5 * 60_000,
+    });
+    const tempDir = mkdtempSync(join(tmpdir(), 'cc-statusline-render-claim-'));
+    const cachePath = join(tempDir, 'cache.json');
+    await writeCache(cache, cachePath);
+    const spawned: SpawnCall[] = [];
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    try {
+      const deps = {
+        cachePath,
+        bundlePath: '/bundle.js',
+        now: () => now,
+        platformOverride: 'linux' as const,
+        spawnRefresh: (
+          command: string,
+          args: string[],
+          opts: SpawnCall['opts'],
+        ) => {
+          spawned.push({ command, args, opts });
+        },
+      };
+
+      await Promise.all([
+        runRenderEnterprise(
+          [],
+          makeStream(loadFixture('stdin-enterprise.json')),
+          deps,
+        ),
+        runRenderEnterprise(
+          [],
+          makeStream(loadFixture('stdin-enterprise.json')),
+          deps,
+        ),
+      ]);
+
+      expect(spawned).toHaveLength(1);
+    } finally {
+      stdout.mockRestore();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('releases the claim when spawning throws', async () => {
+    const now = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      lastUsageRefreshAt: now - 5 * 60_000,
+    });
+    const tempDir = mkdtempSync(join(tmpdir(), 'cc-statusline-render-spawn-'));
+    const cachePath = join(tempDir, 'cache.json');
+    await writeCache(cache, cachePath);
+    let attempts = 0;
+    const deps = {
+      cachePath,
+      bundlePath: '/bundle.js',
+      now: () => now,
+      platformOverride: 'linux' as const,
+      spawnRefresh: () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('spawn failed');
+      },
+    };
+
+    try {
+      await captureStdout(() =>
+        runRenderEnterprise(
+          [],
+          makeStream(loadFixture('stdin-enterprise.json')),
+          deps,
+        ),
+      );
+      await captureStdout(() =>
+        runRenderEnterprise(
+          [],
+          makeStream(loadFixture('stdin-enterprise.json')),
+          deps,
+        ),
+      );
+
+      expect(attempts).toBe(2);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('refresh process boundary', () => {
+  async function captureSpawnForPlatform(
+    platform: NodeJS.Platform,
+    bundlePath: string,
+  ): Promise<SpawnCall> {
+    const now = Date.now();
+    const { spawnCalls } = await runWithCache(
+      makeCacheWithUsage({}, {
+        lastUsageRefreshAt: now - 5 * 60_000,
+      }),
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now, bundlePath, platformOverride: platform },
+    );
+    const call = spawnCalls[0];
+    expect(call).toBeDefined();
+    return call!;
+  }
+
+  it('uses detached Node on POSIX', async () => {
+    const call = await captureSpawnForPlatform('linux', '/bundle.js');
+
+    expect(call.command).toBe(process.execPath);
+    expect(call.args).toEqual([
+      '/bundle.js',
+      'refresh',
+      expect.stringMatching(/^--claimed-at=\d+$/),
+    ]);
+    expect(call.opts).toMatchObject({
+      detached: true,
+      stdio: 'ignore',
+    });
+  });
+
+  it('uses a minimized detached command on Windows', async () => {
+    const call = await captureSpawnForPlatform('win32', 'C:\\bundle.js');
+
+    expect(call.command).toBe('cmd.exe');
+    expect(call.args).toEqual([
+      '/c',
+      'start',
+      '/b',
+      '/min',
+      process.execPath,
+      'C:\\bundle.js',
+      'refresh',
+      expect.stringMatching(/^--claimed-at=\d+$/),
+    ]);
+    expect(call.opts.stdio).toBe('ignore');
+  });
+
+  it('passes only the required environment variables', async () => {
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'super-secret-key');
+    vi.stubEnv('CLAUDE_CONFIG_DIR', '/my/claude');
+    const now = Date.now();
+
+    const { spawnCalls } = await runWithCache(
+      makeCacheWithUsage({}, {
+        lastUsageRefreshAt: now - 5 * 60_000,
+      }),
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    const env = spawnCalls[0]?.opts.env;
+    expect(env).toBeDefined();
+    expect(env?.['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
+    expect(env?.['CLAUDE_CONFIG_DIR']).toBe('/my/claude');
+    expect(Object.keys(env ?? {}).every((key) =>
+      ['PATH', 'HOME', 'USERPROFILE', 'CLAUDE_CONFIG_DIR'].includes(key),
+    )).toBe(true);
+  });
+});
+
+describe('stale threshold configuration', () => {
+  it.each([
+    ['61 seconds old', undefined, 61_000, 1, true],
+    ['59 seconds old', undefined, 59_000, 0, false],
+    ['custom 30ms threshold', '30', 31_000, 1, true],
+    ['minimum threshold clamp', '1000', 11_000, 1, true],
+  ] as const)(
+    '%s',
+    async (_label, configuredThreshold, ageMs, spawnCount, stale) => {
+      if (configuredThreshold !== undefined) {
+        vi.stubEnv(
+          'CC_STATUSLINE_ENTERPRISE_STALE_MS',
+          configuredThreshold,
+        );
+      }
+      vi.stubEnv('NO_COLOR', '1');
+      const now = Date.now();
+
+      const { output, spawnCalls } = await runWithCache(
+        makeCacheWithUsage({}, {
+          lastUsageRefreshAt: now - ageMs,
+        }),
+        loadFixture('stdin-enterprise.json'),
+        { now: () => now },
+      );
+
+      expect(spawnCalls).toHaveLength(spawnCount);
+      expect(output.includes(STALE_MARKER)).toBe(stale);
+    },
+  );
+});
+
+describe('rate-limit rendering', () => {
+  it('does not spawn during cooldown and renders the remaining minutes', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const now = Date.now();
+    const { output, spawnCalls } = await runWithCache(
+      makeCacheWithUsage({}, {
+        lastUsageRefreshAt: now - 5 * 60_000,
+        rateLimitedUntilMs: now + 4 * 60_000,
+      }),
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    expect(spawnCalls).toHaveLength(0);
+    expect(output).toContain(RATE_LIMITED_HINT_PREFIX.trim());
+    expect(output).toContain('retry in 4m');
+  });
+
+  it('renders cooldowns under one minute in seconds', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const now = Date.now();
+    const { output } = await runWithCache(
+      makeCacheWithUsage({}, {
+        lastUsageRefreshAt: now - 30_000,
+        rateLimitedUntilMs: now + 30_000,
+      }),
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    expect(output).toContain('retry in 30s');
+  });
+
+  it('omits an elapsed cooldown', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const now = Date.now();
+    const { output, spawnCalls } = await runWithCache(
+      makeCacheWithUsage({}, {
+        lastUsageRefreshAt: now - 30_000,
+        rateLimitedUntilMs: now - 1,
+      }),
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    expect(output).not.toContain(RATE_LIMITED_HINT_PREFIX.trim());
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('uses adaptive backoff after the upstream cooldown expires', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const now = Date.now();
+    const { output, spawnCalls } = await runWithCache(
+      makeCacheWithUsage({}, {
+        lastUsageRefreshAt: now - 30_000,
+        rateLimitedUntilMs: now - 1_000,
+        nextRefreshAllowedAt: now + 2 * 60_000,
+        consecutiveRateLimitCount: 1,
+      }),
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    expect(output).toContain('retry in 2m');
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it('keeps usage figures alongside the cooldown hint', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const now = Date.now();
+    const { output } = await runWithCache(
+      makeCacheWithUsage({}, {
+        lastUsageRefreshAt: now - 30_000,
+        rateLimitedUntilMs: now + 2 * 60_000,
+      }),
+      loadFixture('stdin-enterprise.json'),
+      { now: () => now },
+    );
+
+    expect(output).toContain('$780.00 / $1000.00 (78%)');
+    expect(output).toContain('retry in 2m');
+  });
+});

--- a/tests/render-enterprise.test.ts
+++ b/tests/render-enterprise.test.ts
@@ -5,121 +5,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { Readable } from 'node:stream';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { SpawnOptions } from 'node:child_process';
-
-const FIXTURES = resolve(__dirname, 'fixtures');
-
-function loadFixture(name: string): string {
-  return readFileSync(resolve(FIXTURES, name), 'utf8');
-}
-
-function makeStream(content: string): Readable {
-  return Readable.from([content]);
-}
-
-// ---------------------------------------------------------------------------
-// Shared cache fixture helpers
-// ---------------------------------------------------------------------------
-
 import type { Cache } from '../src/cache/store';
 import type { UsageResponse } from '../src/oauth/types';
-
-const BASE_CREDENTIALS = {
-  accessToken: 'tok',
-  refreshToken: 'ref',
-  expiresAt: Date.now() + 3600_000,
-};
-
-const GOLDEN_STDIN = JSON.stringify({
-  session_id: 'golden',
-  transcript_path: '/t',
-  cwd: '/c',
-  model: { id: 'claude-opus-4-7', display_name: 'Opus 4.7' },
-  workspace: { current_dir: '/c', project_dir: '/c' },
-  version: '1',
-  output_style: { name: 'default' },
-  cost: {
-    total_cost_usd: 0,
-    total_duration_ms: 0,
-    total_api_duration_ms: 0,
-    total_lines_added: 0,
-    total_lines_removed: 0,
-  },
-  exceeds_200k_tokens: false,
-  context_window: { used_percentage: null },
-});
-
-function makeCache(overrides: Partial<Cache> = {}): Cache {
-  return {
-    schemaVersion: 3,
-    authState: 'ok',
-    credentials: BASE_CREDENTIALS,
-    usage: null,
-    lastUsageRefreshAt: 0,
-    lastRefreshStartedAt: 0,
-    lastErrorMessage: null,
-    rateLimitedUntilMs: 0,
-    nextRefreshAllowedAt: 0,
-    consecutiveRateLimitCount: 0,
-    ...overrides,
-  };
-}
-
-/** Builds a Cache with the full usage-response.json fixture usage. */
-function makeCacheWithUsage(
-  usageOverrides: Partial<UsageResponse> = {},
-  cacheOverrides: Partial<Cache> = {},
-): Cache {
-  const baseUsage = JSON.parse(loadFixture('usage-response.json')) as UsageResponse;
-  const usage: UsageResponse = { ...baseUsage, ...usageOverrides };
-  return makeCache({ usage, ...cacheOverrides });
-}
-
-// ---------------------------------------------------------------------------
-// stdout capture helper
-// ---------------------------------------------------------------------------
-
-function captureStdout(fn: () => Promise<number>): Promise<{ output: string; exitCode: number }> {
-  return new Promise(async (resolve, reject) => {
-    const chunks: string[] = [];
-
-    const spy = vi
-      .spyOn(process.stdout, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        void rest;
-        if (typeof chunk === 'string') {
-          chunks.push(chunk);
-        } else if (Buffer.isBuffer(chunk)) {
-          chunks.push(chunk.toString('utf8'));
-        }
-        return true;
-      });
-
-    try {
-      const exitCode = await fn();
-      spy.mockRestore();
-      resolve({ output: chunks.join(''), exitCode });
-    } catch (err) {
-      spy.mockRestore();
-      reject(err);
-    }
-  });
-}
-
-// ---------------------------------------------------------------------------
-// TTY helpers
-// ---------------------------------------------------------------------------
-
-function setTTY(value: boolean | undefined): void {
-  Object.defineProperty(process.stdout, 'isTTY', {
-    value,
-    writable: true,
-    configurable: true,
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Import the function under test
@@ -128,12 +19,21 @@ function setTTY(value: boolean | undefined): void {
 import {
   runRenderEnterprise,
   AUTH_FATAL_HINT,
+  MISSING_CACHE_HINT,
   CLOUDFLARE_HINT,
-  RATE_LIMITED_HINT_PREFIX,
 } from '../src/subcommands/render-enterprise';
 import { STALE_MARKER, MISSING } from '../src/statusline/format';
 import * as storeModule from '../src/cache/store';
-import type { DiagnosticLogger } from '../src/diagnostics/logger';
+import {
+  captureStdout,
+  GOLDEN_STDIN,
+  loadFixture,
+  makeCache,
+  makeCacheWithUsage,
+  makeStream,
+  runWithCache,
+  setTTY,
+} from './support/render-enterprise';
 
 // ---------------------------------------------------------------------------
 // Global setup / teardown
@@ -148,42 +48,6 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
-
-// Helper that runs runRenderEnterprise with a given cache injected via spy
-async function runWithCache(
-  cache: Cache | null,
-  stdinContent: string,
-  extra: {
-    now?: () => number;
-    logger?: DiagnosticLogger;
-    spawnCalls?: Array<{ command: string; args: string[]; opts: SpawnOptions }>;
-  } = {},
-): Promise<{ output: string; exitCode: number; spawnCalls: Array<{ command: string; args: string[]; opts: SpawnOptions }> }> {
-  const calls: Array<{ command: string; args: string[]; opts: SpawnOptions }> = [];
-  const readCacheSpy = vi.spyOn(storeModule, 'readCache').mockReturnValue(cache);
-
-  try {
-    const { output, exitCode } = await captureStdout(() =>
-      runRenderEnterprise(
-        [],
-        makeStream(stdinContent),
-        {
-          cachePath: '/mocked',
-          bundlePath: '/bundle.js',
-          now: extra.now ?? (() => Date.now()),
-          logger: extra.logger ?? { log: async () => {} },
-          spawnRefresh: (command, args, opts) => {
-            calls.push({ command, args, opts });
-            if (extra.spawnCalls) extra.spawnCalls.push({ command, args, opts });
-          },
-        },
-      ),
-    );
-    return { output, exitCode, spawnCalls: calls };
-  } finally {
-    readCacheSpy.mockRestore();
-  }
-}
 
 describe('golden Enterprise output', () => {
   beforeEach(() => {
@@ -237,10 +101,11 @@ describe('golden Enterprise output', () => {
     expect(output).toBe('Opus 4.7 · 5h 42% [17:22] · 7d 81% [Tue 16:22]\n');
   });
 
-  it('renders exact fetching line', async () => {
-    const { output } = await runWithCache(null, GOLDEN_STDIN);
+  it('renders exact missing-cache repair line', async () => {
+    const { output, spawnCalls } = await runWithCache(null, GOLDEN_STDIN);
 
-    expect(output).toBe('Opus 4.7 · usage — · fetching…\n');
+    expect(output).toBe('Opus 4.7 · usage — · run init\n');
+    expect(spawnCalls).toHaveLength(0);
   });
 });
 
@@ -488,16 +353,17 @@ describe('Scenario 4 (AE3): authState=fatal — dimmed figures + remediation hin
   });
 
   it('auth-fatal hint is at most 50 chars', () => {
+    expect(AUTH_FATAL_HINT).toBe(' run init to repair auth');
     expect(AUTH_FATAL_HINT.trim().length).toBeLessThanOrEqual(50);
   });
 
-  it('does NOT spawn a refresh subprocess when authState=fatal', async () => {
+  it('throttles fatal-auth recovery for five minutes', async () => {
     const NOW = Date.now();
     const cache = makeCacheWithUsage({}, {
       authState: 'fatal',
-      lastUsageRefreshAt: 0, // stale, would normally trigger spawn
+      lastUsageRefreshAt: NOW - 30_000,
+      lastRefreshStartedAt: NOW - 2 * 60_000,
     });
-
     const { spawnCalls } = await runWithCache(
       cache,
       loadFixture('stdin-enterprise.json'),
@@ -506,14 +372,76 @@ describe('Scenario 4 (AE3): authState=fatal — dimmed figures + remediation hin
 
     expect(spawnCalls).toHaveLength(0);
   });
+
+  it('spawns background recovery immediately when fatal auth has never retried', async () => {
+    const NOW = 100;
+    const cache = makeCacheWithUsage({}, {
+      authState: 'fatal',
+      lastUsageRefreshAt: NOW - 30_000,
+      lastRefreshStartedAt: 0,
+    });
+    const { spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      {
+        now: () => NOW,
+      },
+    );
+
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it('spawns fatal-auth recovery again after five minutes', async () => {
+    const NOW = Date.now();
+    const cache = makeCacheWithUsage({}, {
+      authState: 'fatal',
+      lastUsageRefreshAt: NOW - 30_000,
+      lastRefreshStartedAt: NOW - 5 * 60_000,
+    });
+
+    const { spawnCalls } = await runWithCache(
+      cache,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it('honors in-flight and rate-limit guards during fatal-auth recovery', async () => {
+    const NOW = Date.now();
+    const inFlight = makeCacheWithUsage({}, {
+      authState: 'fatal',
+      lastRefreshStartedAt: NOW - 500,
+    });
+    const coolingDown = makeCacheWithUsage({}, {
+      authState: 'fatal',
+      lastRefreshStartedAt: 0,
+      rateLimitedUntilMs: NOW + 60_000,
+    });
+
+    const first = await runWithCache(
+      inFlight,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+    const second = await runWithCache(
+      coolingDown,
+      loadFixture('stdin-enterprise.json'),
+      { now: () => NOW },
+    );
+
+    expect(first.spawnCalls).toHaveLength(0);
+    expect(second.spawnCalls).toHaveLength(0);
+  });
 });
 
 // ============================================================================
-// Scenario 5: Cache missing — output includes usage — + fetching…; spawn called
+// Scenario 5: Cache missing — output includes an actionable init hint
 // ============================================================================
 
 describe('Scenario 5: cache missing (null)', () => {
-  it('renders "usage —" and "fetching…" on first render', async () => {
+  it('renders "usage —" and the init hint without spawning refresh', async () => {
     const { output, exitCode, spawnCalls } = await runWithCache(
       null,
       loadFixture('stdin-enterprise.json'),
@@ -521,9 +449,9 @@ describe('Scenario 5: cache missing (null)', () => {
 
     expect(exitCode).toBe(0);
     expect(output).toContain(`usage ${MISSING}`);
-    expect(output).toContain('fetching…');
-    // Spawn IS called
-    expect(spawnCalls).toHaveLength(1);
+    expect(output).toContain(MISSING_CACHE_HINT);
+    expect(output).not.toContain('fetching…');
+    expect(spawnCalls).toHaveLength(0);
   });
 });
 
@@ -532,16 +460,39 @@ describe('Scenario 5: cache missing (null)', () => {
 // ============================================================================
 
 describe('Scenario 6: cache malformed — readCache returns null', () => {
-  it('renders "usage —" and "fetching…"; spawn called', async () => {
-    // readCache returns null for malformed content — we simulate by passing null.
-    const { output, spawnCalls } = await runWithCache(
-      null,
-      loadFixture('stdin-enterprise.json'),
-    );
+  it('renders the init hint without spawning refresh for malformed v4 JSON', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'cc-statusline-render-malformed-'));
+    const cachePath = join(tmpDir, 'cache.json');
+    const spawnCalls: Array<{
+      command: string;
+      args: string[];
+      opts: SpawnOptions;
+    }> = [];
+    writeFileSync(cachePath, JSON.stringify({ schemaVersion: 4 }), 'utf8');
 
-    expect(output).toContain(`usage ${MISSING}`);
-    expect(output).toContain('fetching…');
-    expect(spawnCalls).toHaveLength(1);
+    try {
+      const { output, exitCode } = await captureStdout(() =>
+        runRenderEnterprise(
+          [],
+          makeStream(loadFixture('stdin-enterprise.json')),
+          {
+            cachePath,
+            bundlePath: '/bundle.js',
+            spawnRefresh: (command, args, opts) => {
+              spawnCalls.push({ command, args, opts });
+            },
+          },
+        ),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain(`usage ${MISSING}`);
+      expect(output).toContain(MISSING_CACHE_HINT);
+      expect(output).not.toContain('fetching…');
+      expect(spawnCalls).toHaveLength(0);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -607,122 +558,6 @@ describe('Scenario 8: stdin missing entirely — silent fail', () => {
     readCacheSpy.mockRestore();
     expect(exitCode).toBe(0);
     expect(output).toBe('\n');
-  });
-});
-
-// ============================================================================
-// Scenario 9 (R14): Stale beyond 15min — dim + STALE_MARKER + spawn called
-// ============================================================================
-
-describe('Scenario 9 (R14): stale beyond 15min — dim + STALE_MARKER + spawn', () => {
-  it('appends STALE_MARKER and fires spawn when cache is 20min old', async () => {
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 20 * 60 * 1000, // 20 min ago
-    });
-
-    const { output, spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(output).toContain(STALE_MARKER);
-    expect(spawnCalls).toHaveLength(1);
-  });
-});
-
-// ============================================================================
-// Scenario 10: In-flight refresh — render proceeds; NO new spawn
-// ============================================================================
-
-describe('Scenario 10: refresh already in-flight — no new spawn', () => {
-  it('does not spawn when lastRefreshStartedAt is 500ms ago', async () => {
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 20 * 60 * 1000, // stale — would normally trigger spawn
-      lastRefreshStartedAt: NOW - 500, // in-flight (within 1s dedup window)
-    });
-
-    const { spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(spawnCalls).toHaveLength(0);
-  });
-});
-
-describe('diagnostic refresh decisions', () => {
-  it('records a stale-cache spawn decision without changing rendered output', async () => {
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 5 * 60 * 1000,
-    });
-    const events: Array<Record<string, unknown>> = [];
-
-    const { output, spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      {
-        now: () => NOW,
-        logger: {
-          log: async (details) => {
-            events.push(details);
-          },
-        },
-      },
-    );
-
-    expect(spawnCalls).toHaveLength(1);
-    expect(output).toContain(STALE_MARKER);
-    expect(events).toContainEqual(expect.objectContaining({
-      event: 'render.refresh_decision',
-      action: 'spawn',
-      reason: 'stale-cache',
-    }));
-  });
-});
-
-// ============================================================================
-// Scenario 11 (R15): Synchronous bound — returns within 30ms even when spawn needed
-// ============================================================================
-
-describe('Scenario 11 (R15): synchronous performance bound', () => {
-  it('returns within 30ms even when spawn is triggered', async () => {
-    const NOW = Date.now();
-    const cache = null; // forces spawn
-
-    const readCacheSpy = vi.spyOn(storeModule, 'readCache').mockReturnValue(cache);
-    let spawnCalled = false;
-
-    const start = performance.now();
-
-    const { exitCode } = await captureStdout(() =>
-      runRenderEnterprise(
-        [],
-        makeStream(loadFixture('stdin-enterprise.json')),
-        {
-          cachePath: '/mocked',
-          bundlePath: '/bundle.js',
-          now: () => NOW,
-          logger: { log: async () => {} },
-          // Simulate async work in spawn — but runRenderEnterprise must not await it.
-          spawnRefresh: (_command, _args, _opts) => {
-            spawnCalled = true;
-            // Simulated slow subprocess — we don't await this, so timing is unaffected.
-          },
-        },
-      ),
-    );
-
-    const elapsed = performance.now() - start;
-    readCacheSpy.mockRestore();
-
-    expect(exitCode).toBe(0);
-    expect(spawnCalled).toBe(true);
-    expect(elapsed).toBeLessThan(30);
   });
 });
 
@@ -847,8 +682,8 @@ describe('Scenario 14: authState=cloudflare-blocked — normal figures + cloudfl
 // Scenario 15: First-render UX then second render with populated cache
 // ============================================================================
 
-describe('Scenario 15: first-render UX → second render without fetching…', () => {
-  it('first render includes fetching…; second render (populated cache) omits it', async () => {
+describe('Scenario 15: init-required UX → populated cache', () => {
+  it('first render requests init; second render shows populated usage', async () => {
     const NOW = Date.now();
 
     // First render: no cache.
@@ -858,8 +693,9 @@ describe('Scenario 15: first-render UX → second render without fetching…', (
       { now: () => NOW },
     );
 
-    expect(firstOutput).toContain('fetching…');
-    expect(firstSpawns).toHaveLength(1);
+    expect(firstOutput).toContain(MISSING_CACHE_HINT);
+    expect(firstOutput).not.toContain('fetching…');
+    expect(firstSpawns).toHaveLength(0);
 
     // Second render: cache now populated.
     const populatedCache = makeCacheWithUsage({}, {
@@ -925,250 +761,6 @@ describe('Scenario 17: global.fetch is never called', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
-  });
-});
-
-// ============================================================================
-// Scenario 18: No file writes from render path
-// ----------------------------------------------------------------------------
-// The render path provably never calls a write API: src/subcommands/
-// render-enterprise.ts imports nothing that can write to disk (no fs writes,
-// no writeCache). vi.spyOn on node:fs's default exports fails with "Cannot
-// redefine property" under CJS, so the structural guarantee at the import
-// graph stands in for a spy assertion here.
-// ============================================================================
-
-// ============================================================================
-// Scenario 19: Windows vs POSIX spawn shape
-// ============================================================================
-
-describe('Scenario 19: spawn shape differs by platform', () => {
-  it('on POSIX: calls spawnRefresh(process.execPath, [bundlePath, "refresh"], { detached: true })', async () => {
-    const NOW = Date.now();
-    const cache = null; // triggers spawn
-
-    const readCacheSpy = vi.spyOn(storeModule, 'readCache').mockReturnValue(cache);
-    const capturedCalls: Array<{ command: string; args: string[]; opts: SpawnOptions }> = [];
-
-    // Ensure platform is POSIX
-    const origPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-
-    try {
-      await captureStdout(() =>
-        runRenderEnterprise(
-          [],
-          makeStream(loadFixture('stdin-enterprise.json')),
-          {
-            cachePath: '/mocked',
-            bundlePath: '/my/bundle.js',
-            now: () => NOW,
-            logger: { log: async () => {} },
-            spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
-          },
-        ),
-      );
-    } finally {
-      Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
-      readCacheSpy.mockRestore();
-    }
-
-    expect(capturedCalls).toHaveLength(1);
-    const call = capturedCalls[0]!;
-    expect(call.command).toBe(process.execPath);
-    expect(call.args).toEqual(['/my/bundle.js', 'refresh']);
-    expect(call.opts.detached).toBe(true);
-    expect(call.opts.stdio).toBe('ignore');
-  });
-
-  it('on win32: calls spawnRefresh("cmd.exe", ["/c", "start", "/b", "/min", execPath, bundlePath, "refresh"])', async () => {
-    const NOW = Date.now();
-    const cache = null; // triggers spawn
-
-    const readCacheSpy = vi.spyOn(storeModule, 'readCache').mockReturnValue(cache);
-    const capturedCalls: Array<{ command: string; args: string[]; opts: SpawnOptions }> = [];
-
-    const origPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-
-    try {
-      await captureStdout(() =>
-        runRenderEnterprise(
-          [],
-          makeStream(loadFixture('stdin-enterprise.json')),
-          {
-            cachePath: '/mocked',
-            bundlePath: 'C:\\bundle.js',
-            now: () => NOW,
-            logger: { log: async () => {} },
-            spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
-          },
-        ),
-      );
-    } finally {
-      Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
-      readCacheSpy.mockRestore();
-    }
-
-    expect(capturedCalls).toHaveLength(1);
-    const call = capturedCalls[0]!;
-    expect(call.command).toBe('cmd.exe');
-    expect(call.args).toEqual(['/c', 'start', '/b', '/min', process.execPath, 'C:\\bundle.js', 'refresh']);
-    expect(call.opts.stdio).toBe('ignore');
-  });
-});
-
-// ============================================================================
-// Scenario 20: Minimal env — no secrets leaked into spawn env
-// ============================================================================
-
-describe('Scenario 20: minimal env — no secrets passed to spawn', () => {
-  it('spawn env does NOT contain AWS_SECRET_ACCESS_KEY', async () => {
-    const NOW = Date.now();
-    const cache = null; // triggers spawn
-
-    // Set a sensitive env var
-    process.env['AWS_SECRET_ACCESS_KEY'] = 'super-secret-key';
-
-    const readCacheSpy = vi.spyOn(storeModule, 'readCache').mockReturnValue(cache);
-    const capturedCalls: Array<{ command: string; args: string[]; opts: SpawnOptions }> = [];
-
-    try {
-      await captureStdout(() =>
-        runRenderEnterprise(
-          [],
-          makeStream(loadFixture('stdin-enterprise.json')),
-          {
-            cachePath: '/mocked',
-            bundlePath: '/bundle.js',
-            now: () => NOW,
-            logger: { log: async () => {} },
-            spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
-          },
-        ),
-      );
-    } finally {
-      delete process.env['AWS_SECRET_ACCESS_KEY'];
-      readCacheSpy.mockRestore();
-    }
-
-    expect(capturedCalls).toHaveLength(1);
-    const env = capturedCalls[0]!.opts.env as NodeJS.ProcessEnv | undefined;
-    expect(env).toBeDefined();
-    expect(env?.['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
-  });
-
-  it('spawn env contains only PATH, HOME/USERPROFILE, and CLAUDE_CONFIG_DIR', async () => {
-    const NOW = Date.now();
-    const cache = null;
-
-    process.env['CLAUDE_CONFIG_DIR'] = '/my/claude';
-    const readCacheSpy = vi.spyOn(storeModule, 'readCache').mockReturnValue(cache);
-    const capturedCalls: Array<{ command: string; args: string[]; opts: SpawnOptions }> = [];
-
-    try {
-      await captureStdout(() =>
-        runRenderEnterprise(
-          [],
-          makeStream(loadFixture('stdin-enterprise.json')),
-          {
-            cachePath: '/mocked',
-            bundlePath: '/bundle.js',
-            now: () => NOW,
-            logger: { log: async () => {} },
-            spawnRefresh: (command, args, opts) => capturedCalls.push({ command, args, opts }),
-          },
-        ),
-      );
-    } finally {
-      delete process.env['CLAUDE_CONFIG_DIR'];
-      readCacheSpy.mockRestore();
-    }
-
-    expect(capturedCalls).toHaveLength(1);
-    const env = capturedCalls[0]!.opts.env as NodeJS.ProcessEnv;
-    const keys = Object.keys(env);
-    const allowedKeys = new Set(['PATH', 'HOME', 'USERPROFILE', 'CLAUDE_CONFIG_DIR']);
-
-    for (const key of keys) {
-      expect(allowedKeys.has(key)).toBe(true);
-    }
-
-    expect(env['CLAUDE_CONFIG_DIR']).toBe('/my/claude');
-  });
-});
-
-// ============================================================================
-// Scenario 21: 60-second stale threshold (new behaviour)
-// ============================================================================
-
-describe('Scenario 21: stale threshold is 60 seconds', () => {
-  it('cache 61s old triggers spawn and STALE_MARKER', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 61 * 1000, // 61 s ago — just past threshold
-    });
-
-    const { output, spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(spawnCalls).toHaveLength(1);
-    expect(output).toContain(STALE_MARKER);
-  });
-
-  it('cache 59s old does NOT spawn and has no STALE_MARKER', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 59 * 1000, // 59 s ago — within threshold
-    });
-
-    const { output, spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(spawnCalls).toHaveLength(0);
-    expect(output).not.toContain(STALE_MARKER);
-  });
-
-  it('honors CC_STATUSLINE_ENTERPRISE_STALE_MS override', async () => {
-    vi.stubEnv('CC_STATUSLINE_ENTERPRISE_STALE_MS', '30');
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 31 * 1000,
-    });
-
-    const { spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(spawnCalls).toHaveLength(1);
-  });
-
-  it('clamps stale-threshold env to minimum (10s)', async () => {
-    vi.stubEnv('CC_STATUSLINE_ENTERPRISE_STALE_MS', '1000');
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 11 * 1000,
-    });
-
-    const { spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(spawnCalls).toHaveLength(1);
   });
 });
 
@@ -1323,120 +915,5 @@ describe('Scenario 22: Enterprise credits and session cost stay source-separated
 
     expect(output).toContain('credits $9.19 / $1000.00 (1%) ~ · session $16.00');
     expect(output).not.toContain('session $16.00 ~');
-  });
-});
-
-// ============================================================================
-// Scenario 23: rate-limit cooldown — no spawn fired, hint appended
-// ============================================================================
-
-describe('Scenario 23: rate-limit cooldown — no spawn, hint appended', () => {
-  it('does NOT spawn refresh when rateLimitedUntilMs is in the future', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 5 * 60 * 1000, // stale — would normally trigger spawn
-      rateLimitedUntilMs: NOW + 4 * 60 * 1000, // 4 min of cooldown remaining
-    });
-
-    const { spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(spawnCalls).toHaveLength(0);
-  });
-
-  it('appends rate-limited hint with minutes remaining', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 30 * 1000,
-      rateLimitedUntilMs: NOW + 4 * 60 * 1000, // 4 min remaining
-    });
-
-    const { output } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(output).toContain(RATE_LIMITED_HINT_PREFIX.trim());
-    expect(output).toMatch(/retry in 4m/);
-  });
-
-  it('uses seconds for sub-minute cooldown', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 30 * 1000,
-      rateLimitedUntilMs: NOW + 30 * 1000, // 30s remaining
-    });
-
-    const { output } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(output).toMatch(/retry in 30s/);
-  });
-
-  it('does NOT show hint once cooldown has elapsed', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 30 * 1000,
-      rateLimitedUntilMs: NOW - 1, // just expired
-    });
-
-    const { output, spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(output).not.toContain(RATE_LIMITED_HINT_PREFIX.trim());
-    // Cache is recent (30s old), so still no spawn — that's fine.
-    expect(spawnCalls).toHaveLength(0);
-  });
-
-  it('uses adaptive backoff cooldown even when rateLimitedUntilMs has expired', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 30 * 1000, // recent by stale rule
-      rateLimitedUntilMs: NOW - 1_000, // expired upstream cooldown
-      nextRefreshAllowedAt: NOW + 2 * 60 * 1000, // still backoff-restricted
-    });
-
-    const { output, spawnCalls } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(output).toContain('retry in 2m');
-    expect(spawnCalls).toHaveLength(0);
-  });
-
-  it('cooldown hint takes precedence over no-hint when no auth issue', async () => {
-    // Sanity: hint must be present alongside the figures.
-    vi.stubEnv('NO_COLOR', '1');
-    const NOW = Date.now();
-    const cache = makeCacheWithUsage({}, {
-      lastUsageRefreshAt: NOW - 30 * 1000,
-      rateLimitedUntilMs: NOW + 2 * 60 * 1000,
-    });
-
-    const { output } = await runWithCache(
-      cache,
-      loadFixture('stdin-enterprise.json'),
-      { now: () => NOW },
-    );
-
-    expect(output).toContain('$780.00 / $1000.00 (78%)');
-    expect(output).toContain('retry in 2m');
   });
 });

--- a/tests/support/render-enterprise.ts
+++ b/tests/support/render-enterprise.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import type { SpawnOptions } from 'node:child_process';
+import { vi } from 'vitest';
+import { writeCache, type Cache } from '../../src/cache/store';
+import type { UsageResponse } from '../../src/oauth/types';
+import { runRenderEnterprise } from '../../src/subcommands/render-enterprise';
+
+const FIXTURES = resolve(__dirname, '..', 'fixtures');
+
+export interface SpawnCall {
+  command: string;
+  args: string[];
+  opts: SpawnOptions;
+}
+
+export const GOLDEN_STDIN = JSON.stringify({
+  session_id: 'golden',
+  transcript_path: '/t',
+  cwd: '/c',
+  model: { id: 'claude-opus-4-7', display_name: 'Opus 4.7' },
+  workspace: { current_dir: '/c', project_dir: '/c' },
+  version: '1',
+  output_style: { name: 'default' },
+  cost: {
+    total_cost_usd: 0,
+    total_duration_ms: 0,
+    total_api_duration_ms: 0,
+    total_lines_added: 0,
+    total_lines_removed: 0,
+  },
+  exceeds_200k_tokens: false,
+  context_window: { used_percentage: null },
+});
+
+export function loadFixture(name: string): string {
+  return readFileSync(resolve(FIXTURES, name), 'utf8');
+}
+
+export function makeStream(content: string): Readable {
+  return Readable.from([content]);
+}
+
+export function makeCache(overrides: Partial<Cache> = {}): Cache {
+  return {
+    schemaVersion: 4,
+    authState: 'ok',
+    credentials: {
+      accessToken: 'tok',
+      expiresAt: Date.now() + 3_600_000,
+    },
+    credentialSource: { kind: 'claude-code' },
+    usage: null,
+    lastUsageRefreshAt: 0,
+    lastRefreshStartedAt: 0,
+    lastErrorMessage: null,
+    rateLimitedUntilMs: 0,
+    nextRefreshAllowedAt: 0,
+    consecutiveRateLimitCount: 0,
+    ...overrides,
+  };
+}
+
+export function makeCacheWithUsage(
+  usageOverrides: Partial<UsageResponse> = {},
+  cacheOverrides: Partial<Cache> = {},
+): Cache {
+  const baseUsage = JSON.parse(
+    loadFixture('usage-response.json'),
+  ) as UsageResponse;
+  return makeCache({
+    usage: { ...baseUsage, ...usageOverrides },
+    ...cacheOverrides,
+  });
+}
+
+export async function captureStdout(
+  fn: () => Promise<number>,
+): Promise<{ output: string; exitCode: number }> {
+  const chunks: string[] = [];
+  const spy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+      void rest;
+      if (typeof chunk === 'string') {
+        chunks.push(chunk);
+      } else if (Buffer.isBuffer(chunk)) {
+        chunks.push(chunk.toString('utf8'));
+      }
+      return true;
+    });
+
+  try {
+    const exitCode = await fn();
+    return { output: chunks.join(''), exitCode };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+export function setTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+export async function runWithCache(
+  cache: Cache | null,
+  stdinContent: string,
+  extra: {
+    now?: () => number;
+    bundlePath?: string;
+    platformOverride?: NodeJS.Platform;
+  } = {},
+): Promise<{
+  output: string;
+  exitCode: number;
+  spawnCalls: SpawnCall[];
+}> {
+  const calls: SpawnCall[] = [];
+  const tempDir = mkdtempSync(join(tmpdir(), 'cc-statusline-render-'));
+  const cachePath = join(tempDir, 'cache.json');
+  if (cache !== null) {
+    await writeCache(cache, cachePath);
+  }
+
+  try {
+    const { output, exitCode } = await captureStdout(() =>
+      runRenderEnterprise(
+        [],
+        makeStream(stdinContent),
+        {
+          cachePath,
+          bundlePath: extra.bundlePath ?? '/bundle.js',
+          now: extra.now ?? (() => Date.now()),
+          platformOverride: extra.platformOverride,
+          spawnRefresh: (command, args, opts) => {
+            calls.push({ command, args, opts });
+          },
+        },
+      ),
+    );
+    return { output, exitCode, spawnCalls: calls };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/tests/support/render-enterprise.ts
+++ b/tests/support/render-enterprise.ts
@@ -114,7 +114,6 @@ export async function runWithCache(
   extra: {
     now?: () => number;
     bundlePath?: string;
-    platformOverride?: NodeJS.Platform;
   } = {},
 ): Promise<{
   output: string;
@@ -137,7 +136,6 @@ export async function runWithCache(
           cachePath,
           bundlePath: extra.bundlePath ?? '/bundle.js',
           now: extra.now ?? (() => Date.now()),
-          platformOverride: extra.platformOverride,
           spawnRefresh: (command, args, opts) => {
             calls.push({ command, args, opts });
           },

--- a/tests/uninstall.test.ts
+++ b/tests/uninstall.test.ts
@@ -76,13 +76,13 @@ function writeRenderer(dir: string): void {
 
 async function writeTestCache(dir: string): Promise<void> {
   const cache: Cache = {
-    schemaVersion: 3,
+    schemaVersion: 4,
     authState: 'ok',
     credentials: {
       accessToken: 'sk-ant-test',
-      refreshToken: 'rt-test',
       expiresAt: Date.now() + 3_600_000,
     },
+    credentialSource: { kind: 'claude-code' },
     usage: {
       five_hour: { utilization: 0.1, resetsAt: '2026-05-03T12:00:00Z' },
       seven_day: { utilization: 0.2, resetsAt: '2026-05-10T00:00:00Z' },


### PR DESCRIPTION
## Summary

Enterprise users who were told to re-run init could remain stuck because init copied the same rejected credential, while cc-statusline could independently rotate Claude Code's refresh token. Interactive Enterprise setup now delegates recovery to the official `claude auth login` flow, rediscovers the resulting credential, and activates the statusline only after the usage API accepts it.

`--plan enterprise` continues to select the plan without disabling interaction. `--non-interactive` and non-TTY runs never launch login; they print the exact login and rerun commands instead.

## Design decisions

- Claude Code now owns token renewal. Cache schema v4 stores only the access token, expiry, usage, and credential-source provenance; older caches intentionally require one new Enterprise init.
- Background refresh rereads the recorded Claude Code or explicit-file source near expiry, after a usage `401`, and during fatal-auth recovery. It never calls the OAuth token endpoint or prompts.
- Init preserves the previous installation until replacement credentials pass validation, and explicit credential paths remain authoritative, canonical, home-scoped regular files.
- Cache transactions and refresh claims are cross-process safe, so concurrent init and renderer activity cannot overwrite newer credentials or launch duplicate refresh workers.
- Credential and HTTP errors remain token-safe, usage response bodies stay covered by the request timeout, and the renderer avoids diagnostic writes on its prompt-critical path.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` - 397 tests across 18 files
- Bundle cold-start and single-file dependency smoke checks
- Isolated coverage for login status outcomes, non-interactive behavior, malformed credentials, stalled response bodies, cache-lock ordering, and concurrent renderers

A live Claude account and Enterprise usage endpoint were unavailable, so the real login/API round trip was not exercised. Subprocess, filesystem, and HTTP behavior is covered through injected system boundaries without touching a real keychain, Claude directory, or network.

Fixes #24

## New concepts

### Filesystem bakery lock

A bakery lock gives each contender an immutable numbered ticket, ordered like customers taking numbers at a counter. A contender first publishes that it is choosing, selects one more than the highest live ticket, then enters only when no chooser remains and its `(ticket, token)` pair sorts first.

| Approach | Risk in this cache |
|---|---|
| Timestamp plus random token | A later same-millisecond contender can sort ahead of the active writer |
| One replaceable lock file | Stale cleanup can accidentally remove a successor that already acquired the path |
| Immutable choosing and ticket files | Ownership can be compared without deleting or replacing another contender's identity |

Here this keeps read-modify-write cache transactions serialized across detached renderer and init processes while still allowing dead contenders to be collected. It is intentionally limited to short local filesystem critical sections; a database lock or platform coordinator is preferable when shared storage, long operations, or distributed hosts are involved.
