### PR TITLE
chore: bump release version to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nkootstra/cc-statusline",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nkootstra/cc-statusline",
-      "version": "0.5.7",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "write-file-atomic": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nkootstra/cc-statusline",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "Usage-aware Claude Code statusline + installer for Pro/Max and Enterprise users",
   "homepage": "https://github.com/nkootstra/cc-statusline#readme",
   "bugs": {


### PR DESCRIPTION
## What

Prepare the `0.6.0` package release with Claude Code-owned Enterprise authentication recovery and reliable cross-platform timing checks. The publish artifact contains only the CLI bundle, launcher, README, license, and package metadata.

Related: #25, #27

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Any changes in `credentials/`, `oauth/`, or `cache/` were discussed in the linked issue
